### PR TITLE
Format code to a consistent style

### DIFF
--- a/cpu-energy-meter.c
+++ b/cpu-energy-meter.c
@@ -34,288 +34,278 @@ uint64_t delay_unit = 1000000000; // unit in nanoseconds
 double **cum_energy_J = NULL;
 struct timeval measurement_start_time, measurement_end_time;
 
-int get_rapl_energy_info(uint64_t power_domain, uint64_t node, double *total_energy_consumed)
-{
-    int err;
+int get_rapl_energy_info(uint64_t power_domain, uint64_t node, double *total_energy_consumed) {
+  int err;
 
-    switch (power_domain) {
-    case PKG:
-	err = get_pkg_total_energy_consumed(node, total_energy_consumed);
-	break;
-    case PP0:
-	err = get_pp0_total_energy_consumed(node, total_energy_consumed);
-	break;
-    case PP1:
-	err = get_pp1_total_energy_consumed(node, total_energy_consumed);
-	break;
-    case DRAM:
-	err = get_dram_total_energy_consumed(node, total_energy_consumed);
-	break;
-    case PSYS:
-	err = get_psys_total_energy_consumed(node, total_energy_consumed);
-	break;
-    default:
-	err = MY_ERROR;
-	break;
+  switch (power_domain) {
+  case PKG:
+    err = get_pkg_total_energy_consumed(node, total_energy_consumed);
+    break;
+  case PP0:
+    err = get_pp0_total_energy_consumed(node, total_energy_consumed);
+    break;
+  case PP1:
+    err = get_pp1_total_energy_consumed(node, total_energy_consumed);
+    break;
+  case DRAM:
+    err = get_dram_total_energy_consumed(node, total_energy_consumed);
+    break;
+  case PSYS:
+    err = get_psys_total_energy_consumed(node, total_energy_consumed);
+    break;
+  default:
+    err = MY_ERROR;
+    break;
+  }
+
+  return err;
+}
+
+void convert_time_to_string(struct timeval tv, char *time_buf) {
+  time_t sec;
+  int msec;
+  struct tm *timeinfo;
+  char tmp_buf[9];
+
+  sec = tv.tv_sec;
+  timeinfo = localtime(&sec);
+  msec = tv.tv_usec / 1000;
+
+  strftime(tmp_buf, 9, "%H:%M:%S", timeinfo);
+  sprintf(time_buf, "%s:%d", tmp_buf, msec);
+}
+
+double convert_time_to_sec(struct timeval tv) {
+  double elapsed_time = (double)(tv.tv_sec) + ((double)(tv.tv_usec) / 1000000);
+  return elapsed_time;
+}
+
+sigset_t get_sigset() {
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGINT);
+  sigaddset(&set, SIGQUIT);
+  sigaddset(&set, SIGUSR1);
+  return set;
+}
+
+void print_intermediate_results() {
+  int i, domain;
+  uint64_t freq;
+
+  double start_seconds = convert_time_to_sec(measurement_start_time);
+  double end_seconds = convert_time_to_sec(measurement_end_time);
+  char end_time_string[12];
+  convert_time_to_string(measurement_end_time, end_time_string);
+  // fprintf(stdout, "curr_time=%f (%s o'clock)\n", end_seconds, end_time_string);
+  fprintf(stdout, "\nduration_seconds=%f\n", end_seconds - start_seconds);
+
+  if (cum_energy_J != NULL) {
+    for (i = 0; i < num_node; i++) {
+      if (cum_energy_J[i] == NULL) {
+        continue;
+      }
+
+      for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
+        if (is_supported_domain(domain)) {
+          char *domain_string = RAPL_DOMAIN_STRINGS[domain];
+          fprintf(stdout, "cpu%d_%s_joules=%f\n", i, domain_string, cum_energy_J[i][domain]);
+        }
+      }
     }
-
-    return err;
-}
-
-void convert_time_to_string(struct timeval tv, char *time_buf)
-{
-    time_t sec;
-    int msec;
-    struct tm *timeinfo;
-    char tmp_buf[9];
-
-    sec = tv.tv_sec;
-    timeinfo = localtime(&sec);
-    msec = tv.tv_usec / 1000;
-
-    strftime(tmp_buf, 9, "%H:%M:%S", timeinfo);
-    sprintf(time_buf, "%s:%d", tmp_buf, msec);
-}
-
-double convert_time_to_sec(struct timeval tv)
-{
-    double elapsed_time = (double)(tv.tv_sec) + ((double)(tv.tv_usec) / 1000000);
-    return elapsed_time;
-}
-
-sigset_t get_sigset()
-{
-    sigset_t set;
-    sigemptyset(&set);
-    sigaddset(&set, SIGINT);
-    sigaddset(&set, SIGQUIT);
-    sigaddset(&set, SIGUSR1);
-    return set;
-}
-
-void print_intermediate_results()
-{
-    int i, domain;
-    uint64_t freq;
-
-    double start_seconds = convert_time_to_sec(measurement_start_time);
-    double end_seconds = convert_time_to_sec(measurement_end_time);
-    char end_time_string[12];
-    convert_time_to_string(measurement_end_time, end_time_string);
-    // fprintf(stdout, "curr_time=%f (%s o'clock)\n", end_seconds, end_time_string);
-    fprintf(stdout, "\nduration_seconds=%f\n", end_seconds - start_seconds);
-
-    if (cum_energy_J != NULL) {
-	for (i = 0; i < num_node; i++) {
-	    if (cum_energy_J[i] == NULL) {
-		continue;
-	    }
-
-	    for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
-		if (is_supported_domain(domain)) {
-		    char *domain_string = RAPL_DOMAIN_STRINGS[domain];
-		    fprintf(stdout, "cpu%d_%s_joules=%f\n", i, domain_string, cum_energy_J[i][domain]);
-		}
-	    }
-	}
-    }
+  }
 }
 
 // Returns 1 if the process is supposed to continue, 0 if the process is supposed to stop
-int handle_signal(int sig, siginfo_t *info)
-{
-    if (sig < 0) {
-	return 1;
+int handle_signal(int sig, siginfo_t *info) {
+  if (sig < 0) {
+    return 1;
 
-    } else if (sig == SIGINT || sig == SIGQUIT) {
-	print_intermediate_results();
-	return 0;
+  } else if (sig == SIGINT || sig == SIGQUIT) {
+    print_intermediate_results();
+    return 0;
 
-    } else if (sig == SIGUSR1) {
-	print_intermediate_results();
-	return 1;
+  } else if (sig == SIGUSR1) {
+    print_intermediate_results();
+    return 1;
 
-    } else {
-	printf("Didn't handle signal number %d", sig);
-	return 1;
-    }
+  } else {
+    printf("Didn't handle signal number %d", sig);
+    return 1;
+  }
 }
 
-void compute_msr_probe_interval_time(struct timespec *signal_timelimit)
-{
-    if (delay) {
-	// delay set by user; i.e. use the according values and return
-	long seconds = delay / delay_unit;
-	long nano_seconds = delay % delay_unit;
+void compute_msr_probe_interval_time(struct timespec *signal_timelimit) {
+  if (delay) {
+    // delay set by user; i.e. use the according values and return
+    long seconds = delay / delay_unit;
+    long nano_seconds = delay % delay_unit;
 
-	signal_timelimit->tv_sec = seconds;
-	signal_timelimit->tv_nsec = nano_seconds;
-	return;
+    signal_timelimit->tv_sec = seconds;
+    signal_timelimit->tv_nsec = nano_seconds;
+    return;
+  }
+
+  double thermal_spec_power = DEFAULT_THERMAL_SPEC_POWER;
+
+  int err = 0;
+  pkg_rapl_parameters_t pkg_parameters;
+
+  err = get_pkg_rapl_parameters(0, &pkg_parameters);
+  if (!err) {
+    double epsilon = 1.0e-03;
+    if ((abs(pkg_parameters.thermal_spec_power_watts - 0) > epsilon) ||
+        (abs(pkg_parameters.maximum_power_watts - 0) > epsilon)) {
+      // if either of the values is not equal to zero, we take the higher value as the new value for
+      // thermal_spec_power.
+      thermal_spec_power =
+          fmax(pkg_parameters.thermal_spec_power_watts, pkg_parameters.maximum_power_watts);
     }
+  }
 
-    double thermal_spec_power = DEFAULT_THERMAL_SPEC_POWER;
-
-    int err = 0;
-    pkg_rapl_parameters_t pkg_parameters;
-
-    err = get_pkg_rapl_parameters(0, &pkg_parameters);
-    if (!err) {
-	double epsilon = 1.0e-03;
-	if ((abs(pkg_parameters.thermal_spec_power_watts - 0) > epsilon) ||
-	    (abs(pkg_parameters.maximum_power_watts - 0) > epsilon)) {
-	    // if either of the values is not equal to zero, we take the higher value as the new value for
-	    // thermal_spec_power.
-	    thermal_spec_power = fmax(pkg_parameters.thermal_spec_power_watts, pkg_parameters.maximum_power_watts);
-	}
-    }
-
-    calculate_probe_interval_time(signal_timelimit, thermal_spec_power);
+  calculate_probe_interval_time(signal_timelimit, thermal_spec_power);
 }
 
-void do_print_energy_info()
-{
-    struct timespec signal_timelimit;
-    compute_msr_probe_interval_time(&signal_timelimit);
+void do_print_energy_info() {
+  struct timespec signal_timelimit;
+  compute_msr_probe_interval_time(&signal_timelimit);
 
-    sigset_t signal_set = get_sigset();
-    int i = 0;
-    int domain = 0;
-    int err = 0;
-    uint64_t node = 0;
-    double new_sample;
-    double delta;
+  sigset_t signal_set = get_sigset();
+  int i = 0;
+  int domain = 0;
+  int err = 0;
+  uint64_t node = 0;
+  double new_sample;
+  double delta;
 
-    double prev_sample[num_node][RAPL_NR_DOMAIN];
-    cum_energy_J = calloc(num_node, sizeof(double *));
-    for (i = 0; i < num_node; i++) {
-	cum_energy_J[i] = calloc(RAPL_NR_DOMAIN, sizeof(double));
+  double prev_sample[num_node][RAPL_NR_DOMAIN];
+  cum_energy_J = calloc(num_node, sizeof(double *));
+  for (i = 0; i < num_node; i++) {
+    cum_energy_J[i] = calloc(RAPL_NR_DOMAIN, sizeof(double));
+  }
+
+  char time_buffer[32];
+  struct timeval tv;
+  int msec;
+  uint64_t tsc;
+  uint64_t freq;
+
+  /* don't buffer if piped */
+  setbuf(stdout, NULL);
+
+  fprintf(stdout, "cpu_count=%lu\n", num_node);
+
+  /* Read initial values */
+  for (i = node; i < num_node; i++) {
+    for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
+      if (is_supported_domain(domain)) {
+        err = get_rapl_energy_info(domain, i, &prev_sample[i][domain]);
+      }
     }
+  }
 
-    char time_buffer[32];
-    struct timeval tv;
-    int msec;
-    uint64_t tsc;
-    uint64_t freq;
+  gettimeofday(&tv, NULL);
+  measurement_start_time = tv;
+  measurement_end_time = measurement_start_time;
 
-    /* don't buffer if piped */
-    setbuf(stdout, NULL);
+  char time_string[12];
+  convert_time_to_string(tv, time_string);
+  // fprintf(stdout, "start_time=%f (%s o'clock)\n", convert_time_to_sec(tv), time_string);
 
-    fprintf(stdout, "cpu_count=%lu\n", num_node);
+  int rcvd_signal;
+  int do_continue = 1;
+  siginfo_t signal_info;
+  /* Begin sampling */
+  while (do_continue) {
+    // If a signal is received, perform one probe before handling it.
+    rcvd_signal = sigtimedwait(&signal_set, &signal_info, &signal_timelimit);
 
-    /* Read initial values */
     for (i = node; i < num_node; i++) {
-	for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
-	    if (is_supported_domain(domain)) {
-		err = get_rapl_energy_info(domain, i, &prev_sample[i][domain]);
-	    }
-	}
+      for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
+        if (is_supported_domain(domain)) {
+          err = get_rapl_energy_info(domain, i, &new_sample);
+          delta = new_sample - prev_sample[i][domain];
+
+          /* Handle wraparound */
+          if (delta < 0) {
+            delta += MAX_ENERGY_STATUS_JOULES;
+          }
+
+          prev_sample[i][domain] = new_sample;
+
+          cum_energy_J[i][domain] += delta;
+        }
+      }
     }
 
     gettimeofday(&tv, NULL);
-    measurement_start_time = tv;
-    measurement_end_time = measurement_start_time;
-
-    char time_string[12];
-    convert_time_to_string(tv, time_string);
-    // fprintf(stdout, "start_time=%f (%s o'clock)\n", convert_time_to_sec(tv), time_string);
-
-    int rcvd_signal;
-    int do_continue = 1;
-    siginfo_t signal_info;
-    /* Begin sampling */
-    while (do_continue) {
-	// If a signal is received, perform one probe before handling it.
-	rcvd_signal = sigtimedwait(&signal_set, &signal_info, &signal_timelimit);
-
-	for (i = node; i < num_node; i++) {
-	    for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
-		if (is_supported_domain(domain)) {
-		    err = get_rapl_energy_info(domain, i, &new_sample);
-		    delta = new_sample - prev_sample[i][domain];
-
-		    /* Handle wraparound */
-		    if (delta < 0) {
-			delta += MAX_ENERGY_STATUS_JOULES;
-		    }
-
-		    prev_sample[i][domain] = new_sample;
-
-		    cum_energy_J[i][domain] += delta;
-		}
-	    }
-	}
-
-	gettimeofday(&tv, NULL);
-	measurement_end_time = tv;
-	if (rcvd_signal != -1) {
-	    do_continue = handle_signal(rcvd_signal, &signal_info);
-	}
+    measurement_end_time = tv;
+    if (rcvd_signal != -1) {
+      do_continue = handle_signal(rcvd_signal, &signal_info);
     }
+  }
 }
 
-void usage()
-{
-    fprintf(stdout, "\nIntel(r) Power Gadget %s\n", version);
-    fprintf(stdout, "\nUsage: \n");
-    fprintf(stdout, "%s [-e [sampling delay (ms) ] optional]\n", progname);
-    fprintf(stdout, "\nExample: %s -e 1000 -d 10\n", progname);
-    fprintf(stdout, "\n");
+void usage() {
+  fprintf(stdout, "\nIntel(r) Power Gadget %s\n", version);
+  fprintf(stdout, "\nUsage: \n");
+  fprintf(stdout, "%s [-e [sampling delay (ms) ] optional]\n", progname);
+  fprintf(stdout, "\nExample: %s -e 1000 -d 10\n", progname);
+  fprintf(stdout, "\n");
 }
 
-int cmdline(int argc, char **argv)
-{
-    int opt;
-    uint64_t delay_ms_temp = 1000;
+int cmdline(int argc, char **argv) {
+  int opt;
+  uint64_t delay_ms_temp = 1000;
 
-    progname = argv[0];
+  progname = argv[0];
 
-    while ((opt = getopt(argc, argv, "e:")) != -1) {
-	switch (opt) {
-	case 'e':
-	    delay_ms_temp = atoi(optarg);
-	    if (delay_ms_temp > 50) {
-		delay = delay_ms_temp * 1000000; // delay in ns
-	    } else {
-		fprintf(stdout, "Sampling delay must be greater than 50 ms.\n");
-		return -1;
-	    }
-	    break;
-	case 'h':
-	    usage();
-	    exit(0);
-	    break;
-	default:
-	    usage();
-	    return -1;
-	}
+  while ((opt = getopt(argc, argv, "e:")) != -1) {
+    switch (opt) {
+    case 'e':
+      delay_ms_temp = atoi(optarg);
+      if (delay_ms_temp > 50) {
+        delay = delay_ms_temp * 1000000; // delay in ns
+      } else {
+        fprintf(stdout, "Sampling delay must be greater than 50 ms.\n");
+        return -1;
+      }
+      break;
+    case 'h':
+      usage();
+      exit(0);
+      break;
+    default:
+      usage();
+      return -1;
     }
+  }
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  int i = 0;
+  int ret = 0;
+
+  sigset_t signal_set = get_sigset();
+  sigprocmask(SIG_BLOCK, &signal_set, NULL);
+  // First init the RAPL library
+  if (0 != init_rapl()) {
+    fprintf(stdout, "Init failed!\n");
+    terminate_rapl();
+    return MY_ERROR;
+  }
+  num_node = get_num_rapl_nodes();
+
+  ret = cmdline(argc, argv);
+  if (ret) { // Error occured while reading command line
+    return ret;
+
+  } else {
+    do_print_energy_info();
+
+    terminate_rapl();
+    sigprocmask(SIG_UNBLOCK, &signal_set, NULL);
     return 0;
-}
-
-int main(int argc, char **argv)
-{
-    int i = 0;
-    int ret = 0;
-
-    sigset_t signal_set = get_sigset();
-    sigprocmask(SIG_BLOCK, &signal_set, NULL);
-    // First init the RAPL library
-    if (0 != init_rapl()) {
-	fprintf(stdout, "Init failed!\n");
-	terminate_rapl();
-	return MY_ERROR;
-    }
-    num_node = get_num_rapl_nodes();
-
-    ret = cmdline(argc, argv);
-    if (ret) { // Error occured while reading command line
-	return ret;
-
-    } else {
-	do_print_energy_info();
-
-	terminate_rapl();
-	sigprocmask(SIG_UNBLOCK, &signal_set, NULL);
-	return 0;
-    }
+  }
 }

--- a/cpu-energy-meter.c
+++ b/cpu-energy-meter.c
@@ -12,59 +12,57 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 /* Written by Martin Dimitrov, Carl Strickland */
 
+#include <assert.h>
+#include <math.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <assert.h>
-#include <unistd.h>
 #include <sys/time.h>
 #include <time.h>
-#include <signal.h>
-#include <math.h>
+#include <unistd.h>
 
 #include "rapl.h"
 
 #define DEFAULT_THERMAL_SPEC_POWER 200.0
 
-char         *progname;
-const char   *version = "2.2";
-uint64_t      num_node = 0;
-uint64_t      delay = 0;
-uint64_t      delay_unit = 1000000000; // unit in nanoseconds
+char *progname;
+const char *version = "2.2";
+uint64_t num_node = 0;
+uint64_t delay = 0;
+uint64_t delay_unit = 1000000000; // unit in nanoseconds
 
 double **cum_energy_J = NULL;
 struct timeval measurement_start_time, measurement_end_time;
 
-int
-get_rapl_energy_info(uint64_t power_domain, uint64_t node, double *total_energy_consumed)
+int get_rapl_energy_info(uint64_t power_domain, uint64_t node, double *total_energy_consumed)
 {
-    int          err;
+    int err;
 
     switch (power_domain) {
     case PKG:
-        err = get_pkg_total_energy_consumed(node, total_energy_consumed);
-        break;
+	err = get_pkg_total_energy_consumed(node, total_energy_consumed);
+	break;
     case PP0:
-        err = get_pp0_total_energy_consumed(node, total_energy_consumed);
-        break;
+	err = get_pp0_total_energy_consumed(node, total_energy_consumed);
+	break;
     case PP1:
-        err = get_pp1_total_energy_consumed(node, total_energy_consumed);
-        break;
+	err = get_pp1_total_energy_consumed(node, total_energy_consumed);
+	break;
     case DRAM:
-        err = get_dram_total_energy_consumed(node, total_energy_consumed);
-        break;
+	err = get_dram_total_energy_consumed(node, total_energy_consumed);
+	break;
     case PSYS:
-        err = get_psys_total_energy_consumed(node, total_energy_consumed);
-        break;
+	err = get_psys_total_energy_consumed(node, total_energy_consumed);
+	break;
     default:
-        err = MY_ERROR;
-        break;
+	err = MY_ERROR;
+	break;
     }
 
     return err;
 }
 
-void
-convert_time_to_string(struct timeval tv, char* time_buf)
+void convert_time_to_string(struct timeval tv, char *time_buf)
 {
     time_t sec;
     int msec;
@@ -73,29 +71,30 @@ convert_time_to_string(struct timeval tv, char* time_buf)
 
     sec = tv.tv_sec;
     timeinfo = localtime(&sec);
-    msec = tv.tv_usec/1000;
+    msec = tv.tv_usec / 1000;
 
     strftime(tmp_buf, 9, "%H:%M:%S", timeinfo);
-    sprintf(time_buf, "%s:%d",tmp_buf,msec);
+    sprintf(time_buf, "%s:%d", tmp_buf, msec);
 }
 
-double
-convert_time_to_sec(struct timeval tv)
+double convert_time_to_sec(struct timeval tv)
 {
-    double elapsed_time = (double)(tv.tv_sec) + ((double)(tv.tv_usec)/1000000);
+    double elapsed_time = (double)(tv.tv_sec) + ((double)(tv.tv_usec) / 1000000);
     return elapsed_time;
 }
 
-sigset_t get_sigset() {
-  sigset_t set;
-  sigemptyset(&set);
-  sigaddset(&set, SIGINT);
-  sigaddset(&set, SIGQUIT);
-  sigaddset(&set, SIGUSR1);
-  return set;
+sigset_t get_sigset()
+{
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGINT);
+    sigaddset(&set, SIGQUIT);
+    sigaddset(&set, SIGUSR1);
+    return set;
 }
 
-void print_intermediate_results() {
+void print_intermediate_results()
+{
     int i, domain;
     uint64_t freq;
 
@@ -103,78 +102,77 @@ void print_intermediate_results() {
     double end_seconds = convert_time_to_sec(measurement_end_time);
     char end_time_string[12];
     convert_time_to_string(measurement_end_time, end_time_string);
-    //fprintf(stdout, "curr_time=%f (%s o'clock)\n", end_seconds, end_time_string);
+    // fprintf(stdout, "curr_time=%f (%s o'clock)\n", end_seconds, end_time_string);
     fprintf(stdout, "\nduration_seconds=%f\n", end_seconds - start_seconds);
 
     if (cum_energy_J != NULL) {
-        for (i = 0; i < num_node; i++) {
-            if (cum_energy_J[i] == NULL) {
-                continue;
-            }
+	for (i = 0; i < num_node; i++) {
+	    if (cum_energy_J[i] == NULL) {
+		continue;
+	    }
 
-            for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
-                if (is_supported_domain(domain)) {
-                    char *domain_string = RAPL_DOMAIN_STRINGS[domain];
-                    fprintf(stdout, "cpu%d_%s_joules=%f\n", i, domain_string, cum_energy_J[i][domain]);
-                }
-            }
-        }
+	    for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
+		if (is_supported_domain(domain)) {
+		    char *domain_string = RAPL_DOMAIN_STRINGS[domain];
+		    fprintf(stdout, "cpu%d_%s_joules=%f\n", i, domain_string, cum_energy_J[i][domain]);
+		}
+	    }
+	}
     }
 }
 
 // Returns 1 if the process is supposed to continue, 0 if the process is supposed to stop
-int handle_signal(int sig, siginfo_t * info) {
-  if (sig < 0) {
-    return 1;
+int handle_signal(int sig, siginfo_t *info)
+{
+    if (sig < 0) {
+	return 1;
 
-  } else if (sig == SIGINT || sig == SIGQUIT) {
-    print_intermediate_results();
-    return 0;
+    } else if (sig == SIGINT || sig == SIGQUIT) {
+	print_intermediate_results();
+	return 0;
 
-  } else if (sig == SIGUSR1) {
-    print_intermediate_results();
-    return 1;
+    } else if (sig == SIGUSR1) {
+	print_intermediate_results();
+	return 1;
 
-  } else {
-    printf("Didn't handle signal number %d", sig);
-    return 1;
-  }
+    } else {
+	printf("Didn't handle signal number %d", sig);
+	return 1;
+    }
 }
 
-void
-compute_msr_probe_interval_time(struct timespec *signal_timelimit)
+void compute_msr_probe_interval_time(struct timespec *signal_timelimit)
 {
     if (delay) {
-        // delay set by user; i.e. use the according values and return
-        long seconds = delay / delay_unit;
-        long nano_seconds = delay % delay_unit;
+	// delay set by user; i.e. use the according values and return
+	long seconds = delay / delay_unit;
+	long nano_seconds = delay % delay_unit;
 
-        signal_timelimit->tv_sec = seconds;
-        signal_timelimit->tv_nsec = nano_seconds;
-        return;
+	signal_timelimit->tv_sec = seconds;
+	signal_timelimit->tv_nsec = nano_seconds;
+	return;
     }
 
     double thermal_spec_power = DEFAULT_THERMAL_SPEC_POWER;
 
-    int                   err = 0;
+    int err = 0;
     pkg_rapl_parameters_t pkg_parameters;
 
     err = get_pkg_rapl_parameters(0, &pkg_parameters);
     if (!err) {
-        double epsilon = 1.0e-03;
-        if ((abs(pkg_parameters.thermal_spec_power_watts - 0) > epsilon) \
-                || (abs(pkg_parameters.maximum_power_watts - 0) > epsilon)) {
-            // if either of the values is not equal to zero, we take the
-            // higher value as the new value for thermal_spec_power.
-            thermal_spec_power = fmax(pkg_parameters.thermal_spec_power_watts, pkg_parameters.maximum_power_watts);
-        }
+	double epsilon = 1.0e-03;
+	if ((abs(pkg_parameters.thermal_spec_power_watts - 0) > epsilon) ||
+	    (abs(pkg_parameters.maximum_power_watts - 0) > epsilon)) {
+	    // if either of the values is not equal to zero, we take the higher value as the new value for
+	    // thermal_spec_power.
+	    thermal_spec_power = fmax(pkg_parameters.thermal_spec_power_watts, pkg_parameters.maximum_power_watts);
+	}
     }
 
     calculate_probe_interval_time(signal_timelimit, thermal_spec_power);
 }
 
-void
-do_print_energy_info()
+void do_print_energy_info()
 {
     struct timespec signal_timelimit;
     compute_msr_probe_interval_time(&signal_timelimit);
@@ -188,9 +186,9 @@ do_print_energy_info()
     double delta;
 
     double prev_sample[num_node][RAPL_NR_DOMAIN];
-    cum_energy_J = calloc(num_node, sizeof(double*));
+    cum_energy_J = calloc(num_node, sizeof(double *));
     for (i = 0; i < num_node; i++) {
-        cum_energy_J[i] = calloc(RAPL_NR_DOMAIN, sizeof(double));
+	cum_energy_J[i] = calloc(RAPL_NR_DOMAIN, sizeof(double));
     }
 
     char time_buffer[32];
@@ -206,11 +204,11 @@ do_print_energy_info()
 
     /* Read initial values */
     for (i = node; i < num_node; i++) {
-        for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
-            if(is_supported_domain(domain)) {
-                err = get_rapl_energy_info(domain, i, &prev_sample[i][domain]);
-            }
-        }
+	for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
+	    if (is_supported_domain(domain)) {
+		err = get_rapl_energy_info(domain, i, &prev_sample[i][domain]);
+	    }
+	}
     }
 
     gettimeofday(&tv, NULL);
@@ -219,44 +217,43 @@ do_print_energy_info()
 
     char time_string[12];
     convert_time_to_string(tv, time_string);
-    //fprintf(stdout, "start_time=%f (%s o'clock)\n", convert_time_to_sec(tv), time_string);
+    // fprintf(stdout, "start_time=%f (%s o'clock)\n", convert_time_to_sec(tv), time_string);
 
     int rcvd_signal;
     int do_continue = 1;
     siginfo_t signal_info;
     /* Begin sampling */
     while (do_continue) {
-        // If a signal is received, perform one probe before handling it.
-        rcvd_signal = sigtimedwait(&signal_set, &signal_info, &signal_timelimit);
+	// If a signal is received, perform one probe before handling it.
+	rcvd_signal = sigtimedwait(&signal_set, &signal_info, &signal_timelimit);
 
-        for (i = node; i < num_node; i++) {
-            for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
-                if (is_supported_domain(domain)) {
-                    err = get_rapl_energy_info(domain, i, &new_sample);
-                    delta = new_sample - prev_sample[i][domain];
+	for (i = node; i < num_node; i++) {
+	    for (domain = 0; domain < RAPL_NR_DOMAIN; ++domain) {
+		if (is_supported_domain(domain)) {
+		    err = get_rapl_energy_info(domain, i, &new_sample);
+		    delta = new_sample - prev_sample[i][domain];
 
-                    /* Handle wraparound */
-                    if (delta < 0) {
-                        delta += MAX_ENERGY_STATUS_JOULES;
-                    }
+		    /* Handle wraparound */
+		    if (delta < 0) {
+			delta += MAX_ENERGY_STATUS_JOULES;
+		    }
 
-                    prev_sample[i][domain] = new_sample;
+		    prev_sample[i][domain] = new_sample;
 
-                    cum_energy_J[i][domain] += delta;
-                }
-            }
-        }
+		    cum_energy_J[i][domain] += delta;
+		}
+	    }
+	}
 
-        gettimeofday(&tv, NULL);
-        measurement_end_time = tv;
-        if (rcvd_signal != -1) {
-          do_continue = handle_signal(rcvd_signal, &signal_info);
-        }
+	gettimeofday(&tv, NULL);
+	measurement_end_time = tv;
+	if (rcvd_signal != -1) {
+	    do_continue = handle_signal(rcvd_signal, &signal_info);
+	}
     }
 }
 
-void
-usage()
+void usage()
 {
     fprintf(stdout, "\nIntel(r) Power Gadget %s\n", version);
     fprintf(stdout, "\nUsage: \n");
@@ -265,39 +262,37 @@ usage()
     fprintf(stdout, "\n");
 }
 
-int
-cmdline(int argc, char **argv)
+int cmdline(int argc, char **argv)
 {
-    int             opt;
-    uint64_t    delay_ms_temp = 1000;
+    int opt;
+    uint64_t delay_ms_temp = 1000;
 
     progname = argv[0];
 
     while ((opt = getopt(argc, argv, "e:")) != -1) {
-        switch (opt) {
-        case 'e':
-            delay_ms_temp = atoi(optarg);
-            if(delay_ms_temp > 50) {
-                delay = delay_ms_temp * 1000000; // delay in ns
-            } else {
-                fprintf(stdout, "Sampling delay must be greater than 50 ms.\n");
-                return -1;
-            }
-            break;
-        case 'h':
-            usage();
-            exit(0);
-            break;
-        default:
-            usage();
-            return -1;
-        }
+	switch (opt) {
+	case 'e':
+	    delay_ms_temp = atoi(optarg);
+	    if (delay_ms_temp > 50) {
+		delay = delay_ms_temp * 1000000; // delay in ns
+	    } else {
+		fprintf(stdout, "Sampling delay must be greater than 50 ms.\n");
+		return -1;
+	    }
+	    break;
+	case 'h':
+	    usage();
+	    exit(0);
+	    break;
+	default:
+	    usage();
+	    return -1;
+	}
     }
     return 0;
 }
 
-int
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
     int i = 0;
     int ret = 0;
@@ -306,21 +301,21 @@ main(int argc, char **argv)
     sigprocmask(SIG_BLOCK, &signal_set, NULL);
     // First init the RAPL library
     if (0 != init_rapl()) {
-        fprintf(stdout, "Init failed!\n");
-        terminate_rapl();
-        return MY_ERROR;
+	fprintf(stdout, "Init failed!\n");
+	terminate_rapl();
+	return MY_ERROR;
     }
     num_node = get_num_rapl_nodes();
 
     ret = cmdline(argc, argv);
     if (ret) { // Error occured while reading command line
-        return ret;
+	return ret;
 
     } else {
-      do_print_energy_info();
+	do_print_energy_info();
 
-      terminate_rapl();
-      sigprocmask(SIG_UNBLOCK, &signal_set, NULL);
-      return 0;
+	terminate_rapl();
+	sigprocmask(SIG_UNBLOCK, &signal_set, NULL);
+	return 0;
     }
 }

--- a/cpuid.c
+++ b/cpuid.c
@@ -11,65 +11,59 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 */
 
 /* Written by Martin Dimitrov, Carl Strickland */
+
 #include <stdio.h>
 
 #include "cpuid.h"
 
-
-void
-cpuid(uint32_t eax_in, uint32_t ecx_in,
-      cpuid_info_t *ci)
+void cpuid(uint32_t eax_in, uint32_t ecx_in, cpuid_info_t *ci)
 {
-    asm (
-#if defined(__LP64__)           /* 64-bit architecture */
-        "cpuid;"                /* execute the cpuid instruction */
-        "movl %%ebx, %[ebx];"   /* save ebx output */
-#else                           /* 32-bit architecture */
-        "pushl %%ebx;"          /* save ebx */
-        "cpuid;"                /* execute the cpuid instruction */
-        "movl %%ebx, %[ebx];"   /* save ebx output */
-        "popl %%ebx;"           /* restore ebx */
+    asm(
+#if defined(__LP64__)	 /* 64-bit architecture */
+	"cpuid;"	      /* execute the cpuid instruction */
+	"movl %%ebx, %[ebx];" /* save ebx output */
+#else			      /* 32-bit architecture */
+	"pushl %%ebx;"	/* save ebx */
+	"cpuid;"	      /* execute the cpuid instruction */
+	"movl %%ebx, %[ebx];" /* save ebx output */
+	"popl %%ebx;"	 /* restore ebx */
 #endif
-        : "=a"(ci->eax), [ebx] "=r"(ci->ebx), "=c"(ci->ecx), "=d"(ci->edx)
-        : "a"(eax_in), "c"(ecx_in)
-    );
+	: "=a"(ci->eax), [ebx] "=r"(ci->ebx), "=c"(ci->ecx), "=d"(ci->edx)
+	: "a"(eax_in), "c"(ecx_in));
 }
 
-cpuid_info_t
-get_vendor_signature()
+cpuid_info_t get_vendor_signature()
 {
     cpuid_info_t info;
     cpuid(0, 0, &info);
     return info;
 }
 
-uint32_t
-get_processor_signature()
+uint32_t get_processor_signature()
 {
     cpuid_info_t info;
     cpuid(0x1, 0, &info);
     return info.eax;
 }
 
-cpuid_info_t
-get_processor_topology(uint32_t level)
+cpuid_info_t get_processor_topology(uint32_t level)
 {
     cpuid_info_t info;
     cpuid(0xb, level, &info);
     return info;
 }
 
-void cast_uint_to_str(char* out, uint32_t in)
+void cast_uint_to_str(char *out, uint32_t in)
 {
     int i;
     uint32_t mask = 0x000000ff;
     for (i = 0; i < 4; i++) {
-        out[i] = (char)((in & (mask<<(i*8))) >> (i*8));
+	out[i] = (char)((in & (mask << (i * 8))) >> (i * 8));
     }
     out[4] = '\0';
 }
 
-void get_vendor_name(char* vendor)
+void get_vendor_name(char *vendor)
 {
     cpuid_info_t c;
     char vendor1[5];

--- a/cpuid.c
+++ b/cpuid.c
@@ -16,64 +16,58 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 #include "cpuid.h"
 
-void cpuid(uint32_t eax_in, uint32_t ecx_in, cpuid_info_t *ci)
-{
-    asm(
-#if defined(__LP64__)	 /* 64-bit architecture */
-	"cpuid;"	      /* execute the cpuid instruction */
-	"movl %%ebx, %[ebx];" /* save ebx output */
-#else			      /* 32-bit architecture */
-	"pushl %%ebx;"	/* save ebx */
-	"cpuid;"	      /* execute the cpuid instruction */
-	"movl %%ebx, %[ebx];" /* save ebx output */
-	"popl %%ebx;"	 /* restore ebx */
+void cpuid(uint32_t eax_in, uint32_t ecx_in, cpuid_info_t *ci) {
+  asm(
+#if defined(__LP64__)       /* 64-bit architecture */
+      "cpuid;"              /* execute the cpuid instruction */
+      "movl %%ebx, %[ebx];" /* save ebx output */
+#else                       /* 32-bit architecture */
+      "pushl %%ebx;"        /* save ebx */
+      "cpuid;"              /* execute the cpuid instruction */
+      "movl %%ebx, %[ebx];" /* save ebx output */
+      "popl %%ebx;"         /* restore ebx */
 #endif
-	: "=a"(ci->eax), [ebx] "=r"(ci->ebx), "=c"(ci->ecx), "=d"(ci->edx)
-	: "a"(eax_in), "c"(ecx_in));
+      : "=a"(ci->eax), [ebx] "=r"(ci->ebx), "=c"(ci->ecx), "=d"(ci->edx)
+      : "a"(eax_in), "c"(ecx_in));
 }
 
-cpuid_info_t get_vendor_signature()
-{
-    cpuid_info_t info;
-    cpuid(0, 0, &info);
-    return info;
+cpuid_info_t get_vendor_signature() {
+  cpuid_info_t info;
+  cpuid(0, 0, &info);
+  return info;
 }
 
-uint32_t get_processor_signature()
-{
-    cpuid_info_t info;
-    cpuid(0x1, 0, &info);
-    return info.eax;
+uint32_t get_processor_signature() {
+  cpuid_info_t info;
+  cpuid(0x1, 0, &info);
+  return info.eax;
 }
 
-cpuid_info_t get_processor_topology(uint32_t level)
-{
-    cpuid_info_t info;
-    cpuid(0xb, level, &info);
-    return info;
+cpuid_info_t get_processor_topology(uint32_t level) {
+  cpuid_info_t info;
+  cpuid(0xb, level, &info);
+  return info;
 }
 
-void cast_uint_to_str(char *out, uint32_t in)
-{
-    int i;
-    uint32_t mask = 0x000000ff;
-    for (i = 0; i < 4; i++) {
-	out[i] = (char)((in & (mask << (i * 8))) >> (i * 8));
-    }
-    out[4] = '\0';
+void cast_uint_to_str(char *out, uint32_t in) {
+  int i;
+  uint32_t mask = 0x000000ff;
+  for (i = 0; i < 4; i++) {
+    out[i] = (char)((in & (mask << (i * 8))) >> (i * 8));
+  }
+  out[4] = '\0';
 }
 
-void get_vendor_name(char *vendor)
-{
-    cpuid_info_t c;
-    char vendor1[5];
-    char vendor2[5];
-    char vendor3[5];
-    cpuid(0, 0, &c);
-    cast_uint_to_str(vendor1, c.ebx);
-    cast_uint_to_str(vendor2, c.edx);
-    cast_uint_to_str(vendor3, c.ecx);
-    sprintf(vendor, "%s%s%s", vendor1, vendor2, vendor3);
+void get_vendor_name(char *vendor) {
+  cpuid_info_t c;
+  char vendor1[5];
+  char vendor2[5];
+  char vendor3[5];
+  cpuid(0, 0, &c);
+  cast_uint_to_str(vendor1, c.ebx);
+  cast_uint_to_str(vendor2, c.edx);
+  cast_uint_to_str(vendor3, c.ecx);
+  sprintf(vendor, "%s%s%s", vendor1, vendor2, vendor3);
 }
 
 #if 0

--- a/cpuid.h
+++ b/cpuid.h
@@ -18,10 +18,10 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include <stdint.h>
 
 typedef struct cpuid_info_t {
-    uint32_t eax;
-    uint32_t ebx;
-    uint32_t ecx;
-    uint32_t edx;
+  uint32_t eax;
+  uint32_t ebx;
+  uint32_t ecx;
+  uint32_t edx;
 } cpuid_info_t;
 
 void cpuid(uint32_t eax_in, uint32_t ecx_in, cpuid_info_t *info);

--- a/cpuid.h
+++ b/cpuid.h
@@ -25,9 +25,13 @@ typedef struct cpuid_info_t {
 } cpuid_info_t;
 
 void cpuid(uint32_t eax_in, uint32_t ecx_in, cpuid_info_t *info);
+
 cpuid_info_t get_vendor_signature();
+
 uint32_t get_processor_signature();
+
 cpuid_info_t get_processor_topology(uint32_t level);
-void get_vendor_name(char* vendor);
+
+void get_vendor_name(char *vendor);
 
 #endif

--- a/intel-family.h
+++ b/intel-family.h
@@ -4,15 +4,14 @@
 /*
  * Mapping from Intel's CPU generation names to their respective family- and model number.
  *
- * For reference, see Intel Architectures Software Developer's Manual Volume 4, Model-Specific Registers, Chapter 2,
- * Table 2-1
+ * For reference, see Intel Architectures Software Developer's Manual Volume 4, Model-Specific
+ * Registers, Chapter 2, Table 2-1
  * (https://software.intel.com/sites/default/files/managed/22/0d/335592-sdm-vol-4.pdf)
- *
  */
 
 /*
-* "Big Core" Processors (Branded as Core, Xeon, etc...).
-* The "_X" parts are generally the EP and EX Xeons.
+* "Big Core" Processors (Branded as Core, Xeon, etc...). The "_X" parts are generally the EP and EX
+* Xeons.
 */
 
 #define CPU_INTEL_SANDYBRIDGE		    0x206A0     // Family 6 Model 42 (0x2a)

--- a/intel-family.h
+++ b/intel-family.h
@@ -3,16 +3,17 @@
 
 /*
  * Mapping from Intel's CPU generation names to their respective family- and model number.
- * 
- * For reference, see Intel Architectures Software Developer's Manual Volume 4, Model-Specific Registers, Chapter 2, Table 2-1
+ *
+ * For reference, see Intel Architectures Software Developer's Manual Volume 4, Model-Specific Registers, Chapter 2,
+ * Table 2-1
  * (https://software.intel.com/sites/default/files/managed/22/0d/335592-sdm-vol-4.pdf)
- * 
+ *
  */
 
- /* 
- * "Big Core" Processors (Branded as Core, Xeon, etc...).
- * The "_X" parts are generally the EP and EX Xeons.
- */
+/*
+* "Big Core" Processors (Branded as Core, Xeon, etc...).
+* The "_X" parts are generally the EP and EX Xeons.
+*/
 
 #define CPU_INTEL_SANDYBRIDGE		    0x206A0     // Family 6 Model 42 (0x2a)
 #define CPU_INTEL_SANDYBRIDGE_X         0x206D0     // Family 6 Model 45 (0x2d)

--- a/msr.c
+++ b/msr.c
@@ -40,8 +40,9 @@ int open_msr_fd(int num_nodes) {
     fd = open(msr_path, O_RDONLY);
     fds[i] = fd;
 
-    if (fd == -1)
+    if (fd == -1) {
       err = MY_ERROR;
+    }
   }
 
   return err;
@@ -57,15 +58,18 @@ int read_msr(int cpu, uint64_t address, uint64_t *value) {
   FILE *fp;
 
   // dup is used here to clone the fd. This way, we can close the stream afterwards, while we still
-  // retain the open file descriptor.
+  // retain an open file descriptor.
   fp = fdopen(dup(fds[cpu]), "r");
   err = fp == NULL;
-  if (!err)
+  if (!err) {
     err = (fseek(fp, address, SEEK_SET) != 0);
-  if (!err)
+  }
+  if (!err) {
     err = (fread(value, sizeof(uint64_t), 1, fp) != 1);
-  if (fp != NULL)
+  }
+  if (fp != NULL) {
     fclose(fp);
+  }
   return err;
 }
 

--- a/msr.c
+++ b/msr.c
@@ -27,25 +27,24 @@ size_t fds_size;
  *
  * Returns 0 on success and MY_ERROR, if at least one msr-file fails to open.
  */
-int open_msr_fd(int num_nodes)
-{
-    int err = 0;
-    int fd = 0;
-    char msr_path[32];
+int open_msr_fd(int num_nodes) {
+  int err = 0;
+  int fd = 0;
+  char msr_path[32];
 
-    fds_size = num_nodes;
-    fds = malloc(fds_size * sizeof(int));
+  fds_size = num_nodes;
+  fds = malloc(fds_size * sizeof(int));
 
-    for (int i = 0; i < fds_size; i++) {
-	sprintf(msr_path, "/dev/cpu/%d/msr", i);
-	fd = open(msr_path, O_RDONLY);
-	fds[i] = fd;
+  for (int i = 0; i < fds_size; i++) {
+    sprintf(msr_path, "/dev/cpu/%d/msr", i);
+    fd = open(msr_path, O_RDONLY);
+    fds[i] = fd;
 
-	if (fd == -1)
-	    err = MY_ERROR;
-    }
+    if (fd == -1)
+      err = MY_ERROR;
+  }
 
-    return err;
+  return err;
 }
 
 /*
@@ -53,22 +52,21 @@ int open_msr_fd(int num_nodes)
  *
  * Will return 0 on success and MY_ERROR on failure.
  */
-int read_msr(int cpu, uint64_t address, uint64_t *value)
-{
-    int err = 0;
-    FILE *fp;
+int read_msr(int cpu, uint64_t address, uint64_t *value) {
+  int err = 0;
+  FILE *fp;
 
-    // dup is used here to clone the fd. This way, we can close the stream afterwards, while we still retain the open
-    // file descriptor.
-    fp = fdopen(dup(fds[cpu]), "r");
-    err = fp == NULL;
-    if (!err)
-	err = (fseek(fp, address, SEEK_SET) != 0);
-    if (!err)
-	err = (fread(value, sizeof(uint64_t), 1, fp) != 1);
-    if (fp != NULL)
-	fclose(fp);
-    return err;
+  // dup is used here to clone the fd. This way, we can close the stream afterwards, while we still
+  // retain the open file descriptor.
+  fp = fdopen(dup(fds[cpu]), "r");
+  err = fp == NULL;
+  if (!err)
+    err = (fseek(fp, address, SEEK_SET) != 0);
+  if (!err)
+    err = (fread(value, sizeof(uint64_t), 1, fp) != 1);
+  if (fp != NULL)
+    fclose(fp);
+  return err;
 }
 
 /*
@@ -76,12 +74,11 @@ int read_msr(int cpu, uint64_t address, uint64_t *value)
  *
  * Close each file descriptor and free the allocated memory for the fds-array.
  */
-void close_msr_fd()
-{
-    for (int i = 0; i < fds_size; i++) {
-	if (fds[i] >= 0) {
-	    close(fds[i]);
-	}
+void close_msr_fd() {
+  for (int i = 0; i < fds_size; i++) {
+    if (fds[i] >= 0) {
+      close(fds[i]);
     }
-    free(fds);
+  }
+  free(fds);
 }

--- a/msr.c
+++ b/msr.c
@@ -12,24 +12,23 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 /* Written by Martin Dimitrov, Carl Strickland */
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <fcntl.h>
 
 #include "msr.h"
 
 int *fds;
 size_t fds_size;
 
-
 /*
  * open_msr_fd
  *
  * Returns 0 on success and MY_ERROR, if at least one msr-file fails to open.
  */
-int
-open_msr_fd(int num_nodes) {
+int open_msr_fd(int num_nodes)
+{
     int err = 0;
     int fd = 0;
     char msr_path[32];
@@ -37,13 +36,13 @@ open_msr_fd(int num_nodes) {
     fds_size = num_nodes;
     fds = malloc(fds_size * sizeof(int));
 
-    for(int i = 0; i < fds_size; i++) {
-        sprintf(msr_path, "/dev/cpu/%d/msr", i);
-        fd = open(msr_path, O_RDONLY);
-        fds[i] = fd;
+    for (int i = 0; i < fds_size; i++) {
+	sprintf(msr_path, "/dev/cpu/%d/msr", i);
+	fd = open(msr_path, O_RDONLY);
+	fds[i] = fd;
 
-        if (fd == -1)
-            err = MY_ERROR;
+	if (fd == -1)
+	    err = MY_ERROR;
     }
 
     return err;
@@ -54,24 +53,21 @@ open_msr_fd(int num_nodes) {
  *
  * Will return 0 on success and MY_ERROR on failure.
  */
-int
-read_msr(int       cpu,
-         uint64_t  address,
-         uint64_t *value)
+int read_msr(int cpu, uint64_t address, uint64_t *value)
 {
     int err = 0;
     FILE *fp;
 
-    // dup is used here to clone the fd. This way, we can close the
-    // stream afterwards, while we still retain the open file descriptor.
+    // dup is used here to clone the fd. This way, we can close the stream afterwards, while we still retain the open
+    // file descriptor.
     fp = fdopen(dup(fds[cpu]), "r");
     err = fp == NULL;
     if (!err)
-        err = (fseek(fp, address, SEEK_SET) != 0);
+	err = (fseek(fp, address, SEEK_SET) != 0);
     if (!err)
-        err = (fread(value, sizeof(uint64_t), 1, fp) != 1);
+	err = (fread(value, sizeof(uint64_t), 1, fp) != 1);
     if (fp != NULL)
-        fclose(fp);
+	fclose(fp);
     return err;
 }
 
@@ -80,12 +76,12 @@ read_msr(int       cpu,
  *
  * Close each file descriptor and free the allocated memory for the fds-array.
  */
-void
-close_msr_fd() {
+void close_msr_fd()
+{
     for (int i = 0; i < fds_size; i++) {
-        if (fds[i] >= 0) {
-            close(fds[i]);
-        }
+	if (fds[i] >= 0) {
+	    close(fds[i]);
+	}
     }
     free(fds);
 }

--- a/msr.h
+++ b/msr.h
@@ -19,8 +19,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 #define MY_ERROR -1
 
-/* Replacement for pow() where the base is 2 and the power is unsigned and less than 31 (will get invalid numbers if 31
- * or greater) */
+/* Replacement for pow() where the base is 2 and the power is unsigned and less than 31 (will get
+ * invalid numbers if 31 or greater) */
 #define B2POW(e) (((e) == 0) ? 1 : (2 << ((e)-1)))
 
 /* General */
@@ -50,39 +50,39 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 /* General */
 typedef struct rapl_unit_multiplier_msr_t {
-    uint64_t power : 4;
-    uint64_t : 4;
-    uint64_t energy : 5;
-    uint64_t : 3;
-    uint64_t time : 4;
-    uint64_t : 32;
-    uint64_t : 12;
+  uint64_t power : 4;
+  uint64_t : 4;
+  uint64_t energy : 5;
+  uint64_t : 3;
+  uint64_t time : 4;
+  uint64_t : 32;
+  uint64_t : 12;
 } rapl_unit_multiplier_msr_t;
 
 /* Updated every ~1ms. Wraparound time of 60s under load. */
 typedef struct energy_status_msr_t {
-    uint64_t total_energy_consumed : 32;
-    uint64_t : 32;
+  uint64_t total_energy_consumed : 32;
+  uint64_t : 32;
 } energy_status_msr_t;
 
 /* PKG domain */
 typedef struct rapl_parameters_msr_t {
-    unsigned int thermal_spec_power : 15;
-    unsigned int : 1;
-    unsigned int minimum_power : 15;
-    unsigned int : 1;
-    unsigned int maximum_power : 15;
-    unsigned int : 1;
-    unsigned int maximum_limit_time_window : 6;
-    unsigned int : 10;
+  unsigned int thermal_spec_power : 15;
+  unsigned int : 1;
+  unsigned int minimum_power : 15;
+  unsigned int : 1;
+  unsigned int maximum_power : 15;
+  unsigned int : 1;
+  unsigned int maximum_limit_time_window : 6;
+  unsigned int : 10;
 } rapl_parameters_msr_t;
 
 /*
- * For documentation see: "Intel64 and IA-32 Architectures Software Developer's Manual" Volume 4: Model-Specific
- * registers.
+ * For documentation see: "Intel64 and IA-32 Architectures Software Developer's Manual" Volume 4:
+ * Model-Specific registers.
  * (Link: https://software.intel.com/sites/default/files/managed/22/0d/335592-sdm-vol-4.pdf)
- * In a nutshell, search the manual and find the MSR number that you wish to read. Then use the read_msr_t function to
- * get the info you need.
+ * In a nutshell, search the manual and find the MSR number that you wish to read. Then use the
+ * read_msr_t function to get the info you need.
  */
 
 /**

--- a/msr.h
+++ b/msr.h
@@ -19,83 +19,83 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 #define MY_ERROR -1
 
-/* Replacement for pow() where the base is 2 and the power is unsigned and
- * less than 31 (will get invalid numbers if 31 or greater) */
-#define B2POW(e) (((e) == 0) ? 1 : (2 << ((e) - 1)))
+/* Replacement for pow() where the base is 2 and the power is unsigned and less than 31 (will get invalid numbers if 31
+ * or greater) */
+#define B2POW(e) (((e) == 0) ? 1 : (2 << ((e)-1)))
 
 /* General */
 #define MSR_RAPL_POWER_UNIT 0x606 /* Unit Multiplier used in RAPL Interfaces (R/O) */
 
 /* Package RAPL Domain */
-#define MSR_RAPL_PKG_POWER_LIMIT   0x610 /* PKG RAPL Power Limit Control (R/W) */
+#define MSR_RAPL_PKG_POWER_LIMIT 0x610   /* PKG RAPL Power Limit Control (R/W) */
 #define MSR_RAPL_PKG_ENERGY_STATUS 0x611 /* PKG Energy Status (R/O) */
-#define MSR_RAPL_PKG_POWER_INFO    0x614 /* PKG RAPL Parameters (R/O) */
+#define MSR_RAPL_PKG_POWER_INFO 0x614    /* PKG RAPL Parameters (R/O) */
 
 /* DRAM RAPL Domain */
-#define MSR_RAPL_DRAM_POWER_LIMIT   0x618 /* DRAM RAPL Power Limit Control (R/W) */
+#define MSR_RAPL_DRAM_POWER_LIMIT 0x618   /* DRAM RAPL Power Limit Control (R/W) */
 #define MSR_RAPL_DRAM_ENERGY_STATUS 0x619 /* DRAM Energy Status (R/O) */
 
 /* PP0 RAPL Domain */
-#define MSR_RAPL_PP0_POWER_LIMIT   0x638 /* PP0 RAPL Power Limit Control (R/W) */
+#define MSR_RAPL_PP0_POWER_LIMIT 0x638   /* PP0 RAPL Power Limit Control (R/W) */
 #define MSR_RAPL_PP0_ENERGY_STATUS 0x639 /* PP0 Energy Status (R/O) */
 
 /* PP1 RAPL Domain */
-#define MSR_RAPL_PP1_POWER_LIMIT   0x640 /* PP1 RAPL Power Limit Control (R/W) */
+#define MSR_RAPL_PP1_POWER_LIMIT 0x640   /* PP1 RAPL Power Limit Control (R/W) */
 #define MSR_RAPL_PP1_ENERGY_STATUS 0x641 /* PP1 Energy Status (R/O) */
 
 /* PSYS RAPL Domain */
 #define MSR_RAPL_PLATFORM_ENERGY_STATUS 0x64d /* PSYS Energy Status */
 
-
 /* Common MSR Structures */
 
 /* General */
 typedef struct rapl_unit_multiplier_msr_t {
-    uint64_t power  : 4;
-    uint64_t        : 4;
+    uint64_t power : 4;
+    uint64_t : 4;
     uint64_t energy : 5;
-    uint64_t        : 3;
-    uint64_t time   : 4;
-    uint64_t        : 32;
-    uint64_t        : 12;
+    uint64_t : 3;
+    uint64_t time : 4;
+    uint64_t : 32;
+    uint64_t : 12;
 } rapl_unit_multiplier_msr_t;
 
 /* Updated every ~1ms. Wraparound time of 60s under load. */
 typedef struct energy_status_msr_t {
     uint64_t total_energy_consumed : 32;
-    uint64_t                       : 32;
+    uint64_t : 32;
 } energy_status_msr_t;
 
 /* PKG domain */
 typedef struct rapl_parameters_msr_t {
-    unsigned int thermal_spec_power        : 15;
-    unsigned int                           : 1;
-    unsigned int minimum_power             : 15;
-    unsigned int                           : 1;
-    unsigned int maximum_power             : 15;
-    unsigned int                           : 1;
+    unsigned int thermal_spec_power : 15;
+    unsigned int : 1;
+    unsigned int minimum_power : 15;
+    unsigned int : 1;
+    unsigned int maximum_power : 15;
+    unsigned int : 1;
     unsigned int maximum_limit_time_window : 6;
-    unsigned int                           : 10;
+    unsigned int : 10;
 } rapl_parameters_msr_t;
 
 /*
- *  For documentation see: "Intel64 and IA-32 Architectures Software Developer's Manual" Volume 4:  Model-Specific registers.
- * https://software.intel.com/sites/default/files/managed/22/0d/335592-sdm-vol-4.pdf In a nutshell, search the manual and 
- * find the MSR number that you wish to read.
- * Then use the read_msr_t function to get the info you need.
+ * For documentation see: "Intel64 and IA-32 Architectures Software Developer's Manual" Volume 4: Model-Specific
+ * registers.
+ * (Link: https://software.intel.com/sites/default/files/managed/22/0d/335592-sdm-vol-4.pdf)
+ * In a nutshell, search the manual and find the MSR number that you wish to read. Then use the read_msr_t function to
+ * get the info you need.
  */
 
 /**
  * Open and store file descriptors in an array for as often as specified in the num_nodes param.
  *
- * @return            0 on success and MY_ERROR, if at least one node fails to open
+ * @return 0 on success and MY_ERROR, if at least one node fails to open
  */
 int open_msr_fd(int num_nodes);
 
 /**
  * Read the given MSR on the given CPU.
  *
- * @return            0 on success and MY_ERROR on failure
+ * @return 0 on success and MY_ERROR on failure
  */
 int read_msr(int cpu, uint64_t address, uint64_t *val);
 

--- a/rapl.c
+++ b/rapl.c
@@ -71,13 +71,15 @@ int bind_context(cpu_set_t *new_context, cpu_set_t *old_context) {
 
   if (old_context != NULL) {
     err = sched_getaffinity(0, sizeof(cpu_set_t), old_context);
-    if (0 != err)
+    if (0 != err) {
       ret = MY_ERROR;
+    }
   }
 
   err += sched_setaffinity(0, sizeof(cpu_set_t), new_context);
-  if (0 != err)
+  if (0 != err) {
     ret = MY_ERROR;
+  }
 
   return ret;
 }
@@ -140,8 +142,9 @@ int build_topology() {
     num_core_threads = info_l0.ebx & 0xffff;
     num_pkg_threads = info_l1.ebx & 0xffff;
 
-    if (os_map[i].pkg_id > max_pkg)
+    if (os_map[i].pkg_id > max_pkg) {
       max_pkg = os_map[i].pkg_id;
+    }
 
     err = bind_context(&prev_context, NULL);
 
@@ -154,8 +157,9 @@ int build_topology() {
 
   // Construct a pkg map: pkg_map[pkg id][APIC_ID ... APIC_ID]
   pkg_map = (APIC_ID_t **)malloc(num_nodes * sizeof(APIC_ID_t *));
-  for (i = 0; i < num_nodes; i++)
+  for (i = 0; i < num_nodes; i++) {
     pkg_map[i] = (APIC_ID_t *)malloc(num_pkg_threads * sizeof(APIC_ID_t));
+  }
 
   uint64_t p, t;
   for (i = 0; i < os_cpu_count; i++) {
@@ -269,17 +273,20 @@ int terminate_rapl() {
 
   close_msr_fd();
 
-  if (NULL != os_map)
+  if (NULL != os_map) {
     free(os_map);
+  }
 
   if (NULL != pkg_map) {
-    for (i = 0; i < num_nodes; i++)
+    for (i = 0; i < num_nodes; i++) {
       free(pkg_map[i]);
+    }
     free(pkg_map);
   }
 
-  if (NULL != msr_support_table)
+  if (NULL != msr_support_table) {
     free(msr_support_table);
+  }
 
   return 0;
 }

--- a/rapl.c
+++ b/rapl.c
@@ -58,117 +58,113 @@ APIC_ID_t *os_map;
 APIC_ID_t **pkg_map;
 
 typedef struct rapl_unit_multiplier_t {
-    double power;
-    double energy;
-    double time;
+  double power;
+  double energy;
+  double time;
 } rapl_unit_multiplier_t;
 
 // OS specific
-int bind_context(cpu_set_t *new_context, cpu_set_t *old_context)
-{
+int bind_context(cpu_set_t *new_context, cpu_set_t *old_context) {
 
-    int err = 0;
-    int ret = 0;
+  int err = 0;
+  int ret = 0;
 
-    if (old_context != NULL) {
-	err = sched_getaffinity(0, sizeof(cpu_set_t), old_context);
-	if (0 != err)
-	    ret = MY_ERROR;
-    }
-
-    err += sched_setaffinity(0, sizeof(cpu_set_t), new_context);
+  if (old_context != NULL) {
+    err = sched_getaffinity(0, sizeof(cpu_set_t), old_context);
     if (0 != err)
-	ret = MY_ERROR;
+      ret = MY_ERROR;
+  }
 
-    return ret;
+  err += sched_setaffinity(0, sizeof(cpu_set_t), new_context);
+  if (0 != err)
+    ret = MY_ERROR;
+
+  return ret;
 }
 
-int bind_cpu(uint64_t cpu, cpu_set_t *old_context)
-{
+int bind_cpu(uint64_t cpu, cpu_set_t *old_context) {
 
-    int err = 0;
-    cpu_set_t cpu_context;
+  int err = 0;
+  cpu_set_t cpu_context;
 
-    CPU_ZERO(&cpu_context);
-    CPU_SET(cpu, &cpu_context);
-    err += bind_context(&cpu_context, old_context);
+  CPU_ZERO(&cpu_context);
+  CPU_SET(cpu, &cpu_context);
+  err += bind_context(&cpu_context, old_context);
 
-    return err;
+  return err;
 }
 
 // Parse the x2APIC_ID_t into SMT, core and package ID.
 // http://software.intel.com/en-us/articles/intel-64-architecture-processor-topology-enumeration
-void parse_apic_id(cpuid_info_t info_l0, cpuid_info_t info_l1, APIC_ID_t *my_id)
-{
+void parse_apic_id(cpuid_info_t info_l0, cpuid_info_t info_l1, APIC_ID_t *my_id) {
 
-    // Get the SMT ID
-    uint64_t smt_mask_width = info_l0.eax & 0x1f;
-    uint64_t smt_mask = ~((-1) << smt_mask_width);
-    my_id->smt_id = info_l0.edx & smt_mask;
+  // Get the SMT ID
+  uint64_t smt_mask_width = info_l0.eax & 0x1f;
+  uint64_t smt_mask = ~((-1) << smt_mask_width);
+  my_id->smt_id = info_l0.edx & smt_mask;
 
-    // Get the core ID
-    uint64_t core_mask_width = info_l1.eax & 0x1f;
-    uint64_t core_mask = (~((-1) << core_mask_width)) ^ smt_mask;
-    my_id->core_id = (info_l1.edx & core_mask) >> smt_mask_width;
+  // Get the core ID
+  uint64_t core_mask_width = info_l1.eax & 0x1f;
+  uint64_t core_mask = (~((-1) << core_mask_width)) ^ smt_mask;
+  my_id->core_id = (info_l1.edx & core_mask) >> smt_mask_width;
 
-    // Get the package ID
-    uint64_t pkg_mask = (-1) << core_mask_width;
-    my_id->pkg_id = (info_l1.edx & pkg_mask) >> core_mask_width;
+  // Get the package ID
+  uint64_t pkg_mask = (-1) << core_mask_width;
+  my_id->pkg_id = (info_l1.edx & pkg_mask) >> core_mask_width;
 }
 
 // For documentation, see:
 // http://software.intel.com/en-us/articles/intel-64-architecture-processor-topology-enumeration
-int build_topology()
-{
+int build_topology() {
 
-    int err;
-    uint64_t i, j;
-    uint64_t max_pkg = 0;
-    os_cpu_count = sysconf(_SC_NPROCESSORS_CONF);
-    cpu_set_t curr_context;
-    cpu_set_t prev_context;
+  int err;
+  uint64_t i, j;
+  uint64_t max_pkg = 0;
+  os_cpu_count = sysconf(_SC_NPROCESSORS_CONF);
+  cpu_set_t curr_context;
+  cpu_set_t prev_context;
 
-    // Construct an os map: os_map[APIC_ID ... APIC_ID]
-    os_map = (APIC_ID_t *)malloc(os_cpu_count * sizeof(APIC_ID_t));
+  // Construct an os map: os_map[APIC_ID ... APIC_ID]
+  os_map = (APIC_ID_t *)malloc(os_cpu_count * sizeof(APIC_ID_t));
 
-    for (i = 0; i < os_cpu_count; i++) {
+  for (i = 0; i < os_cpu_count; i++) {
 
-	err = bind_cpu(i, &prev_context);
+    err = bind_cpu(i, &prev_context);
 
-	cpuid_info_t info_l0 = get_processor_topology(0);
-	cpuid_info_t info_l1 = get_processor_topology(1);
+    cpuid_info_t info_l0 = get_processor_topology(0);
+    cpuid_info_t info_l1 = get_processor_topology(1);
 
-	os_map[i].os_id = i;
-	parse_apic_id(info_l0, info_l1, &os_map[i]);
+    os_map[i].os_id = i;
+    parse_apic_id(info_l0, info_l1, &os_map[i]);
 
-	num_core_threads = info_l0.ebx & 0xffff;
-	num_pkg_threads = info_l1.ebx & 0xffff;
+    num_core_threads = info_l0.ebx & 0xffff;
+    num_pkg_threads = info_l1.ebx & 0xffff;
 
-	if (os_map[i].pkg_id > max_pkg)
-	    max_pkg = os_map[i].pkg_id;
+    if (os_map[i].pkg_id > max_pkg)
+      max_pkg = os_map[i].pkg_id;
 
-	err = bind_context(&prev_context, NULL);
+    err = bind_context(&prev_context, NULL);
 
-	// printf("smt_id: %u core_id: %u pkg_id: %u os_id: %u\n",
-	//   os_map[i].smt_id, os_map[i].core_id, os_map[i].pkg_id, os_map[i].os_id);
-    }
+    // printf("smt_id: %u core_id: %u pkg_id: %u os_id: %u\n",
+    //   os_map[i].smt_id, os_map[i].core_id, os_map[i].pkg_id, os_map[i].os_id);
+  }
 
-    num_pkg_cores = num_pkg_threads / num_core_threads;
-    num_nodes = max_pkg + 1;
+  num_pkg_cores = num_pkg_threads / num_core_threads;
+  num_nodes = max_pkg + 1;
 
-    // Construct a pkg map: pkg_map[pkg id][APIC_ID ... APIC_ID]
-    pkg_map = (APIC_ID_t **)malloc(num_nodes * sizeof(APIC_ID_t *));
-    for (i = 0; i < num_nodes; i++)
-	pkg_map[i] = (APIC_ID_t *)malloc(num_pkg_threads * sizeof(APIC_ID_t));
+  // Construct a pkg map: pkg_map[pkg id][APIC_ID ... APIC_ID]
+  pkg_map = (APIC_ID_t **)malloc(num_nodes * sizeof(APIC_ID_t *));
+  for (i = 0; i < num_nodes; i++)
+    pkg_map[i] = (APIC_ID_t *)malloc(num_pkg_threads * sizeof(APIC_ID_t));
 
-    uint64_t p, t;
-    for (i = 0; i < os_cpu_count; i++) {
-	p = os_map[i].pkg_id;
-	t = os_map[i].smt_id * num_pkg_cores + os_map[i].core_id;
-	pkg_map[p][t] = os_map[i];
-    }
+  uint64_t p, t;
+  for (i = 0; i < os_cpu_count; i++) {
+    p = os_map[i].pkg_id;
+    t = os_map[i].smt_id * num_pkg_cores + os_map[i].core_id;
+    pkg_map[p][t] = os_map[i];
+  }
 
-    return err;
+  return err;
 }
 
 /*!
@@ -177,123 +173,123 @@ int build_topology()
  * This function must be called before calling any other function from the power_gov library.
  * \return 0 on success, -1 otherwise
  */
-int init_rapl()
-{
-    int err = 0;
+int init_rapl() {
+  int err = 0;
 
-    cpuid_info_t sig;
-    sig = get_vendor_signature();
-    if (sig.ebx != 0x756e6547 || sig.ecx != 0x6c65746e || sig.edx != 0x49656e69) {
-	char vendor[12];
-	get_vendor_name(vendor);
-	fprintf(stderr, "The processor on the working machine is not from Intel. Found %s-processor instead.\n",
-		vendor);
-	return MY_ERROR;
-    }
+  cpuid_info_t sig;
+  sig = get_vendor_signature();
+  if (sig.ebx != 0x756e6547 || sig.ecx != 0x6c65746e || sig.edx != 0x49656e69) {
+    char vendor[12];
+    get_vendor_name(vendor);
+    fprintf(stderr,
+            "The processor on the working machine is not from Intel. Found %s-processor instead.\n",
+            vendor);
+    return MY_ERROR;
+  }
 
-    unsigned int family;
-    processor_signature = get_processor_signature();
-    family = (processor_signature >> 8) & 0xf;
-    if (family != 6) {
-	// CPUID.family == 6 means it's anything from Pentium Pro (1995) to the latest Kaby Lake (2017) except
-	// "Netburst"
-	fprintf(stderr, "The Intel processor must be from family 6, but instead a cpu from family %d was found.\n",
-		family);
-	return MY_ERROR;
-    }
+  unsigned int family;
+  processor_signature = get_processor_signature();
+  family = (processor_signature >> 8) & 0xf;
+  if (family != 6) {
+    // CPUID.family == 6 means it's anything from Pentium Pro (1995) to the latest Kaby Lake (2017)
+    // except
+    // "Netburst"
+    fprintf(
+        stderr,
+        "The Intel processor must be from family 6, but instead a cpu from family %d was found.\n",
+        family);
+    return MY_ERROR;
+  }
 
-    err = build_topology();
-    if (err) {
-	fprintf(stderr, "An error occured while binding the cpu and/or the context.\n");
-	return MY_ERROR;
-    }
+  err = build_topology();
+  if (err) {
+    fprintf(stderr, "An error occured while binding the cpu and/or the context.\n");
+    return MY_ERROR;
+  }
 
-    err = open_msr_fd(num_nodes);
-    if (err) {
-	fprintf(stderr, "An error occurred while opening the msr file through a FD.\n");
-	return MY_ERROR;
-    }
+  err = open_msr_fd(num_nodes);
+  if (err) {
+    fprintf(stderr, "An error occurred while opening the msr file through a FD.\n");
+    return MY_ERROR;
+  }
 
-    drop_root_privileges_by_id(PERMANENT, UID_NOBODY, GID_NOGROUP);
+  drop_root_privileges_by_id(PERMANENT, UID_NOBODY, GID_NOGROUP);
 
-    // calloc sets the allocated memory to zero (unlike malloc, where this is not the case)
-    msr_support_table = (unsigned char *)calloc(MSR_SUPPORT_MASK, sizeof(unsigned char));
+  // calloc sets the allocated memory to zero (unlike malloc, where this is not the case)
+  msr_support_table = (unsigned char *)calloc(MSR_SUPPORT_MASK, sizeof(unsigned char));
 
-    uint64_t msr;
-    int cpu = 0;
-    int err_read_msr = 0;
+  uint64_t msr;
+  int cpu = 0;
+  int err_read_msr = 0;
 
-    err_read_msr = read_msr(cpu, MSR_RAPL_POWER_UNIT, &msr);
-    msr_support_table[MSR_RAPL_POWER_UNIT & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_POWER_UNIT, &msr);
+  msr_support_table[MSR_RAPL_POWER_UNIT & MSR_SUPPORT_MASK] = !err_read_msr;
 
-    err_read_msr = read_msr(cpu, MSR_RAPL_PKG_POWER_LIMIT, &msr);
-    msr_support_table[MSR_RAPL_PKG_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
-    err_read_msr = read_msr(cpu, MSR_RAPL_PKG_ENERGY_STATUS, &msr);
-    msr_support_table[MSR_RAPL_PKG_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
-    err_read_msr = read_msr(cpu, MSR_RAPL_PKG_POWER_INFO, &msr);
-    msr_support_table[MSR_RAPL_PKG_POWER_INFO & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_PKG_POWER_LIMIT, &msr);
+  msr_support_table[MSR_RAPL_PKG_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_PKG_ENERGY_STATUS, &msr);
+  msr_support_table[MSR_RAPL_PKG_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_PKG_POWER_INFO, &msr);
+  msr_support_table[MSR_RAPL_PKG_POWER_INFO & MSR_SUPPORT_MASK] = !err_read_msr;
 
-    err_read_msr = read_msr(cpu, MSR_RAPL_DRAM_POWER_LIMIT, &msr);
-    msr_support_table[MSR_RAPL_DRAM_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
-    err_read_msr = read_msr(cpu, MSR_RAPL_DRAM_ENERGY_STATUS, &msr);
-    msr_support_table[MSR_RAPL_DRAM_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_DRAM_POWER_LIMIT, &msr);
+  msr_support_table[MSR_RAPL_DRAM_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_DRAM_ENERGY_STATUS, &msr);
+  msr_support_table[MSR_RAPL_DRAM_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
 
-    err_read_msr = read_msr(cpu, MSR_RAPL_PP0_POWER_LIMIT, &msr);
-    msr_support_table[MSR_RAPL_PP0_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
-    err_read_msr = read_msr(cpu, MSR_RAPL_PP0_ENERGY_STATUS, &msr);
-    msr_support_table[MSR_RAPL_PP0_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_PP0_POWER_LIMIT, &msr);
+  msr_support_table[MSR_RAPL_PP0_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_PP0_ENERGY_STATUS, &msr);
+  msr_support_table[MSR_RAPL_PP0_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
 
-    err_read_msr = read_msr(cpu, MSR_RAPL_PP1_POWER_LIMIT, &msr);
-    msr_support_table[MSR_RAPL_PP1_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
-    err_read_msr = read_msr(cpu, MSR_RAPL_PP1_ENERGY_STATUS, &msr);
-    msr_support_table[MSR_RAPL_PP1_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_PP1_POWER_LIMIT, &msr);
+  msr_support_table[MSR_RAPL_PP1_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_PP1_ENERGY_STATUS, &msr);
+  msr_support_table[MSR_RAPL_PP1_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
 
-    err_read_msr = read_msr(cpu, MSR_RAPL_PLATFORM_ENERGY_STATUS, &msr);
-    msr_support_table[MSR_RAPL_PLATFORM_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
+  err_read_msr = read_msr(cpu, MSR_RAPL_PLATFORM_ENERGY_STATUS, &msr);
+  msr_support_table[MSR_RAPL_PLATFORM_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
 
-    err = read_rapl_units();
+  err = read_rapl_units();
 
-    /* 32 is the width of these fields when they are stored */
-    MAX_ENERGY_STATUS_JOULES = (double)(RAPL_ENERGY_UNIT * (pow(2, 32) - 1));
+  /* 32 is the width of these fields when they are stored */
+  MAX_ENERGY_STATUS_JOULES = (double)(RAPL_ENERGY_UNIT * (pow(2, 32) - 1));
 
-    return err;
+  return err;
 }
 
 /*!
  * \brief Terminate the power_gov library.
  *
- * Call this function function to cleanup resources and terminate the
- * power_gov library.
+ * Call this function function to cleanup resources and terminate the power_gov library.
  * \return 0 on success
  */
-int terminate_rapl()
-{
-    uint64_t i;
+int terminate_rapl() {
+  uint64_t i;
 
-    close_msr_fd();
+  close_msr_fd();
 
-    if (NULL != os_map)
-	free(os_map);
+  if (NULL != os_map)
+    free(os_map);
 
-    if (NULL != pkg_map) {
-	for (i = 0; i < num_nodes; i++)
-	    free(pkg_map[i]);
-	free(pkg_map);
-    }
+  if (NULL != pkg_map) {
+    for (i = 0; i < num_nodes; i++)
+      free(pkg_map[i]);
+    free(pkg_map);
+  }
 
-    if (NULL != msr_support_table)
-	free(msr_support_table);
+  if (NULL != msr_support_table)
+    free(msr_support_table);
 
-    return 0;
+  return 0;
 }
 
 /*!
  * \brief Check if MSR is supported on this machine.
  * \return 1 if supported, 0 otherwise
  */
-uint64_t is_supported_msr(uint64_t msr)
-{
-    return (uint64_t)msr_support_table[msr & MSR_SUPPORT_MASK];
+uint64_t is_supported_msr(uint64_t msr) {
+  return (uint64_t)msr_support_table[msr & MSR_SUPPORT_MASK];
 }
 
 /*!
@@ -303,267 +299,254 @@ uint64_t is_supported_msr(uint64_t msr)
  *
  * \return 1 if supported, 0 otherwise
  */
-uint64_t is_supported_domain(uint64_t power_domain)
-{
-    uint64_t supported = 0;
+uint64_t is_supported_domain(uint64_t power_domain) {
+  uint64_t supported = 0;
 
-    switch (power_domain) {
-    case RAPL_PKG:
-	supported = is_supported_msr(MSR_RAPL_PKG_POWER_LIMIT);
-	supported &= is_supported_msr(MSR_RAPL_PKG_ENERGY_STATUS);
-	break;
-    case RAPL_PP0:
-	supported = is_supported_msr(MSR_RAPL_PP0_POWER_LIMIT);
-	supported &= is_supported_msr(MSR_RAPL_PP0_ENERGY_STATUS);
-	break;
-    case RAPL_PP1:
-	supported = is_supported_msr(MSR_RAPL_PP1_POWER_LIMIT);
-	supported &= is_supported_msr(MSR_RAPL_PP1_ENERGY_STATUS);
-	break;
-    case RAPL_DRAM:
-	supported = is_supported_msr(MSR_RAPL_DRAM_POWER_LIMIT);
-	supported &= is_supported_msr(MSR_RAPL_DRAM_ENERGY_STATUS);
-	break;
-    case RAPL_PSYS:
-	supported = is_supported_msr(MSR_RAPL_PLATFORM_ENERGY_STATUS);
-	break;
-    }
+  switch (power_domain) {
+  case RAPL_PKG:
+    supported = is_supported_msr(MSR_RAPL_PKG_POWER_LIMIT);
+    supported &= is_supported_msr(MSR_RAPL_PKG_ENERGY_STATUS);
+    break;
+  case RAPL_PP0:
+    supported = is_supported_msr(MSR_RAPL_PP0_POWER_LIMIT);
+    supported &= is_supported_msr(MSR_RAPL_PP0_ENERGY_STATUS);
+    break;
+  case RAPL_PP1:
+    supported = is_supported_msr(MSR_RAPL_PP1_POWER_LIMIT);
+    supported &= is_supported_msr(MSR_RAPL_PP1_ENERGY_STATUS);
+    break;
+  case RAPL_DRAM:
+    supported = is_supported_msr(MSR_RAPL_DRAM_POWER_LIMIT);
+    supported &= is_supported_msr(MSR_RAPL_DRAM_ENERGY_STATUS);
+    break;
+  case RAPL_PSYS:
+    supported = is_supported_msr(MSR_RAPL_PLATFORM_ENERGY_STATUS);
+    break;
+  }
 
-    return supported;
+  return supported;
 }
 
 /*!
  * \brief Get the number of RAPL nodes on this machine.
  *
- * Get the number of package power domains, that you can control using RAPL. This is equal to the number of CPU packages
- * in the system.
+ * Get the number of package power domains, that you can control using RAPL. This is equal to the
+ * number of CPU packages in the system.
  *
  * \return number of RAPL nodes.
  */
-uint64_t get_num_rapl_nodes()
-{
-    return num_nodes;
+uint64_t get_num_rapl_nodes() {
+  return num_nodes;
 }
 
-uint64_t get_cpu_from_node(uint64_t node)
-{
-    return pkg_map[node][0].os_id;
+uint64_t get_cpu_from_node(uint64_t node) {
+  return pkg_map[node][0].os_id;
 }
 
-int get_rapl_unit_multiplier(uint64_t cpu, rapl_unit_multiplier_t *unit_obj)
-{
-    int err = 0;
-    uint64_t msr;
-    rapl_unit_multiplier_msr_t unit_msr;
+int get_rapl_unit_multiplier(uint64_t cpu, rapl_unit_multiplier_t *unit_obj) {
+  int err = 0;
+  uint64_t msr;
+  rapl_unit_multiplier_msr_t unit_msr;
 
-    err = !is_supported_msr(MSR_RAPL_POWER_UNIT);
-    if (!err) {
-	err = read_msr(cpu, MSR_RAPL_POWER_UNIT, &msr);
-    }
-    if (!err) {
-	unit_msr = *(rapl_unit_multiplier_msr_t *)&msr;
+  err = !is_supported_msr(MSR_RAPL_POWER_UNIT);
+  if (!err) {
+    err = read_msr(cpu, MSR_RAPL_POWER_UNIT, &msr);
+  }
+  if (!err) {
+    unit_msr = *(rapl_unit_multiplier_msr_t *)&msr;
 
-	unit_obj->time = 1.0 / (double)(B2POW(unit_msr.time));
-	unit_obj->energy = 1.0 / (double)(B2POW(unit_msr.energy));
-	unit_obj->power = 1.0 / (double)(B2POW(unit_msr.power));
-    }
+    unit_obj->time = 1.0 / (double)(B2POW(unit_msr.time));
+    unit_obj->energy = 1.0 / (double)(B2POW(unit_msr.energy));
+    unit_obj->power = 1.0 / (double)(B2POW(unit_msr.power));
+  }
 
-    return err;
+  return err;
 }
 
 /* Common methods (should not be interfaced directly) */
 
-int get_total_energy_consumed(uint64_t cpu, uint64_t msr_address, double *total_energy_consumed_joules)
-{
-    int err = 0;
-    uint64_t msr;
-    energy_status_msr_t domain_msr;
-    cpu_set_t old_context;
+int get_total_energy_consumed(uint64_t cpu, uint64_t msr_address,
+                              double *total_energy_consumed_joules) {
+  int err = 0;
+  uint64_t msr;
+  energy_status_msr_t domain_msr;
+  cpu_set_t old_context;
 
-    err = !is_supported_msr(msr_address);
-    if (!err) {
-	bind_cpu(cpu, &old_context); // improve performance on Linux
-	err = read_msr(cpu, msr_address, &msr);
-	bind_context(&old_context, NULL);
+  err = !is_supported_msr(msr_address);
+  if (!err) {
+    bind_cpu(cpu, &old_context); // improve performance on Linux
+    err = read_msr(cpu, msr_address, &msr);
+    bind_context(&old_context, NULL);
+  }
+
+  if (!err) {
+    domain_msr = *(energy_status_msr_t *)&msr;
+
+    switch (msr_address) {
+    case MSR_RAPL_DRAM_ENERGY_STATUS:
+      *total_energy_consumed_joules = RAPL_DRAM_ENERGY_UNIT * domain_msr.total_energy_consumed;
+      break;
+    default:
+      *total_energy_consumed_joules = RAPL_ENERGY_UNIT * domain_msr.total_energy_consumed;
+      break;
     }
+  }
 
-    if (!err) {
-	domain_msr = *(energy_status_msr_t *)&msr;
-
-	switch (msr_address) {
-	case MSR_RAPL_DRAM_ENERGY_STATUS:
-	    *total_energy_consumed_joules = RAPL_DRAM_ENERGY_UNIT * domain_msr.total_energy_consumed;
-	    break;
-	default:
-	    *total_energy_consumed_joules = RAPL_ENERGY_UNIT * domain_msr.total_energy_consumed;
-	    break;
-	}
-    }
-
-    return err;
+  return err;
 }
 
 /*!
  * \brief Get a pointer to the RAPL PKG energy consumed register.
  *
- * This read-only register provides energy consumed in joules for the package power domain since the last machine reboot
- * (or energy register wraparound)
+ * This read-only register provides energy consumed in joules for the package power domain since the
+ * last machine reboot (or energy register wraparound)
  *
  * \return 0 on success, -1 otherwise
  */
-int get_pkg_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
-{
-    uint64_t cpu = get_cpu_from_node(node);
-    return get_total_energy_consumed(cpu, MSR_RAPL_PKG_ENERGY_STATUS, total_energy_consumed_joules);
+int get_pkg_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules) {
+  uint64_t cpu = get_cpu_from_node(node);
+  return get_total_energy_consumed(cpu, MSR_RAPL_PKG_ENERGY_STATUS, total_energy_consumed_joules);
 }
 
 /*
  * Energy units are either hard-coded, or come from RAPL Energy Unit MSR.
  */
-double rapl_dram_energy_units_probe(double rapl_energy_units)
-{
-    switch (processor_signature & 0xfffffff0) {
-    case CPU_INTEL_HASWELL_X:
-    case CPU_INTEL_BROADWELL_X:
-    case CPU_INTEL_BROADWELL_XEON_D:
-    case CPU_INTEL_SKYLAKE_X:
-    case CPU_INTEL_XEON_PHI_KNL:
-    case CPU_INTEL_XEON_PHI_KNM:
-	return 15.3E-6;
-    default:
-	return rapl_energy_units;
-    }
+double rapl_dram_energy_units_probe(double rapl_energy_units) {
+  switch (processor_signature & 0xfffffff0) {
+  case CPU_INTEL_HASWELL_X:
+  case CPU_INTEL_BROADWELL_X:
+  case CPU_INTEL_BROADWELL_XEON_D:
+  case CPU_INTEL_SKYLAKE_X:
+  case CPU_INTEL_XEON_PHI_KNL:
+  case CPU_INTEL_XEON_PHI_KNM:
+    return 15.3E-6;
+  default:
+    return rapl_energy_units;
+  }
 }
 
 /*!
  * \brief Get a pointer to the RAPL DRAM energy consumed register.
  *
- * This read-only register provides energy consumed in joules for the DRAM power domain since the last machine reboot
- * (or energy register wraparound)
+ * This read-only register provides energy consumed in joules for the DRAM power domain since the
+ * last machine reboot (or energy register wraparound)
  *
  * \return 0 on success, -1 otherwise
  */
-int get_dram_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
-{
-    uint64_t cpu = get_cpu_from_node(node);
-    return get_total_energy_consumed(cpu, MSR_RAPL_DRAM_ENERGY_STATUS, total_energy_consumed_joules);
+int get_dram_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules) {
+  uint64_t cpu = get_cpu_from_node(node);
+  return get_total_energy_consumed(cpu, MSR_RAPL_DRAM_ENERGY_STATUS, total_energy_consumed_joules);
 }
 
 /*!
  * \brief Get a pointer to the RAPL PP0 energy consumed register.
  *
- * This read-only register provides energy consumed in joules for the PP0 (core) power domain since the last machine
- * reboot (or energy register wraparound)
+ * This read-only register provides energy consumed in joules for the PP0 (core) power domain since
+ * the last machine reboot (or energy register wraparound)
  *
  * \return 0 on success, -1 otherwise
  */
-int get_pp0_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
-{
-    uint64_t cpu = get_cpu_from_node(node);
-    return get_total_energy_consumed(cpu, MSR_RAPL_PP0_ENERGY_STATUS, total_energy_consumed_joules);
+int get_pp0_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules) {
+  uint64_t cpu = get_cpu_from_node(node);
+  return get_total_energy_consumed(cpu, MSR_RAPL_PP0_ENERGY_STATUS, total_energy_consumed_joules);
 }
 
 /*!
  * \brief Get a pointer to the RAPL PP1 energy consumed register.
  *
- * This read-only register provides energy consumed in joules for the PP1 (uncore) power domain since the last machine
- * reboot (or energy register wraparound)
+ * This read-only register provides energy consumed in joules for the PP1 (uncore) power domain
+ * since the last machine reboot (or energy register wraparound)
  *
  * \return 0 on success, -1 otherwise
  */
-int get_pp1_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
-{
-    uint64_t cpu = get_cpu_from_node(node);
-    return get_total_energy_consumed(cpu, MSR_RAPL_PP1_ENERGY_STATUS, total_energy_consumed_joules);
+int get_pp1_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules) {
+  uint64_t cpu = get_cpu_from_node(node);
+  return get_total_energy_consumed(cpu, MSR_RAPL_PP1_ENERGY_STATUS, total_energy_consumed_joules);
 }
 
 /*!
  * \brief Get a pointer to the RAPL plattform energy (psys) consumed register.
  *
- * This read-only register provides energy consumed in joules for the PSYS domain since the last machine reboot (or
- * energy register wraparound)
+ * This read-only register provides energy consumed in joules for the PSYS domain since the last
+ * machine reboot (or energy register wraparound)
  *
- * According to Intel Software Devlopers Manual Volume 4, Table 2-38, the consumed energy is the total energy consumed
- * by all devices in the plattform that receive power from integrated power delivery mechanism. Included plattform
- * devices are processor cores, SOC, memory, add-on or peripheral devies that get powered directly from the platform
- * power delivery means.
+ * According to Intel Software Devlopers Manual Volume 4, Table 2-38, the consumed energy is the
+ * total energy consumed by all devices in the plattform that receive power from integrated power
+ * delivery mechanism. Included plattform devices are processor cores, SOC, memory, add-on or
+ * peripheral devies that get powered directly from the platform power delivery means.
  *
  * \return 0 on success, -1 otherwise
  */
-int get_psys_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
-{
-    uint64_t cpu = get_cpu_from_node(node);
-    return get_total_energy_consumed(cpu, MSR_RAPL_PLATFORM_ENERGY_STATUS, total_energy_consumed_joules);
+int get_psys_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules) {
+  uint64_t cpu = get_cpu_from_node(node);
+  return get_total_energy_consumed(cpu, MSR_RAPL_PLATFORM_ENERGY_STATUS,
+                                   total_energy_consumed_joules);
 }
 
-double convert_to_watts(unsigned int raw)
-{
-    return RAPL_POWER_UNIT * raw;
+double convert_to_watts(unsigned int raw) {
+  return RAPL_POWER_UNIT * raw;
 }
 
-double convert_to_seconds(unsigned int raw)
-{
-    return RAPL_TIME_UNIT * raw;
+double convert_to_seconds(unsigned int raw) {
+  return RAPL_TIME_UNIT * raw;
 }
 
 /*!
  * \brief Get a pointer to the RAPL PKG power info register
  *
- * This read-only register provides information about the max/min power limiting settings available on the machine. This
- * register is defined in the pkg_rapl_parameters_t data structure.
+ * This read-only register provides information about the max/min power limiting settings available
+ * on the machine. This register is defined in the pkg_rapl_parameters_t data structure.
  *
  * \return 0 on success, -1 otherwise
  */
-int get_pkg_rapl_parameters(unsigned int node, pkg_rapl_parameters_t *pkg_obj)
-{
-    int err = 0;
-    uint64_t msr;
-    rapl_parameters_msr_t domain_msr;
+int get_pkg_rapl_parameters(unsigned int node, pkg_rapl_parameters_t *pkg_obj) {
+  int err = 0;
+  uint64_t msr;
+  rapl_parameters_msr_t domain_msr;
 
-    err = !is_supported_msr(MSR_RAPL_PKG_POWER_INFO);
-    if (!err) {
-	unsigned int cpu = get_cpu_from_node(node);
-	err = read_msr(cpu, MSR_RAPL_PKG_POWER_INFO, &msr);
-    }
+  err = !is_supported_msr(MSR_RAPL_PKG_POWER_INFO);
+  if (!err) {
+    unsigned int cpu = get_cpu_from_node(node);
+    err = read_msr(cpu, MSR_RAPL_PKG_POWER_INFO, &msr);
+  }
 
-    if (!err) {
-	domain_msr = *(rapl_parameters_msr_t *)&msr;
+  if (!err) {
+    domain_msr = *(rapl_parameters_msr_t *)&msr;
 
-	pkg_obj->thermal_spec_power_watts = convert_to_watts(domain_msr.thermal_spec_power);
-	pkg_obj->minimum_power_watts = convert_to_watts(domain_msr.minimum_power);
-	pkg_obj->maximum_power_watts = convert_to_watts(domain_msr.maximum_power);
-	pkg_obj->maximum_limit_time_window_seconds = convert_to_seconds(domain_msr.maximum_limit_time_window);
-    }
+    pkg_obj->thermal_spec_power_watts = convert_to_watts(domain_msr.thermal_spec_power);
+    pkg_obj->minimum_power_watts = convert_to_watts(domain_msr.minimum_power);
+    pkg_obj->maximum_power_watts = convert_to_watts(domain_msr.maximum_power);
+    pkg_obj->maximum_limit_time_window_seconds =
+        convert_to_seconds(domain_msr.maximum_limit_time_window);
+  }
 
-    return err;
+  return err;
 }
 
-void calculate_probe_interval_time(struct timespec *signal_timelimit, double thermal_spec_power)
-{
-    double result = ((pow(2, 32) - 1) * RAPL_ENERGY_UNIT) / thermal_spec_power;
-    result = result / 2 - 1;
+void calculate_probe_interval_time(struct timespec *signal_timelimit, double thermal_spec_power) {
+  double result = ((pow(2, 32) - 1) * RAPL_ENERGY_UNIT) / thermal_spec_power;
+  result = result / 2 - 1;
 
-    long seconds = floor(result);
-    long nano_seconds = result * pow(10, 9) - seconds * pow(10, 9);
+  long seconds = floor(result);
+  long nano_seconds = result * pow(10, 9) - seconds * pow(10, 9);
 
-    signal_timelimit->tv_sec = seconds;
-    signal_timelimit->tv_nsec = nano_seconds;
+  signal_timelimit->tv_sec = seconds;
+  signal_timelimit->tv_nsec = nano_seconds;
 }
 
 /* Utilities */
 
-int read_rapl_units()
-{
-    int err = 0;
-    rapl_unit_multiplier_t unit_multiplier;
+int read_rapl_units() {
+  int err = 0;
+  rapl_unit_multiplier_t unit_multiplier;
 
-    err = get_rapl_unit_multiplier(0, &unit_multiplier);
-    if (!err) {
-	RAPL_TIME_UNIT = unit_multiplier.time;
-	RAPL_ENERGY_UNIT = unit_multiplier.energy;
-	RAPL_DRAM_ENERGY_UNIT = rapl_dram_energy_units_probe(unit_multiplier.energy);
-	RAPL_POWER_UNIT = unit_multiplier.power;
-    }
+  err = get_rapl_unit_multiplier(0, &unit_multiplier);
+  if (!err) {
+    RAPL_TIME_UNIT = unit_multiplier.time;
+    RAPL_ENERGY_UNIT = unit_multiplier.energy;
+    RAPL_DRAM_ENERGY_UNIT = rapl_dram_energy_units_probe(unit_multiplier.energy);
+    RAPL_POWER_UNIT = unit_multiplier.power;
+  }
 
-    return err;
+  return err;
 }

--- a/rapl.c
+++ b/rapl.c
@@ -13,8 +13,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 /* Written by Martin Dimitrov, Carl Strickland
  * http://software.intel.com/en-us/articles/power-gov */
 
-
-
 /*! \file rapl.c
  * Intel(r) Power Governor library implementation
  */
@@ -23,11 +21,11 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #define _GNU_SOURCE
 #endif
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <assert.h>
 #include <math.h>
 #include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "cpuid.h"
@@ -36,13 +34,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "rapl.h"
 #include "util.h"
 
-char* RAPL_DOMAIN_STRINGS[RAPL_NR_DOMAIN] = {
-    "package",
-    "core",
-    "uncore",
-    "dram",
-    "psys"
-};
+char *RAPL_DOMAIN_STRINGS[RAPL_NR_DOMAIN] = {"package", "core", "uncore", "dram", "psys"};
 
 /* rapl msr availablility */
 #define MSR_SUPPORT_MASK 0xff
@@ -72,27 +64,27 @@ typedef struct rapl_unit_multiplier_t {
 } rapl_unit_multiplier_t;
 
 // OS specific
-int
-bind_context(cpu_set_t *new_context, cpu_set_t *old_context) {
+int bind_context(cpu_set_t *new_context, cpu_set_t *old_context)
+{
 
     int err = 0;
     int ret = 0;
 
     if (old_context != NULL) {
-      err = sched_getaffinity(0, sizeof(cpu_set_t), old_context);
-      if(0 != err)
-        ret = MY_ERROR;
+	err = sched_getaffinity(0, sizeof(cpu_set_t), old_context);
+	if (0 != err)
+	    ret = MY_ERROR;
     }
 
     err += sched_setaffinity(0, sizeof(cpu_set_t), new_context);
-    if(0 != err)
-        ret = MY_ERROR;
+    if (0 != err)
+	ret = MY_ERROR;
 
     return ret;
 }
 
-int
-bind_cpu(uint64_t cpu, cpu_set_t *old_context) {
+int bind_cpu(uint64_t cpu, cpu_set_t *old_context)
+{
 
     int err = 0;
     cpu_set_t cpu_context;
@@ -106,8 +98,8 @@ bind_cpu(uint64_t cpu, cpu_set_t *old_context) {
 
 // Parse the x2APIC_ID_t into SMT, core and package ID.
 // http://software.intel.com/en-us/articles/intel-64-architecture-processor-topology-enumeration
-void
-parse_apic_id(cpuid_info_t info_l0, cpuid_info_t info_l1, APIC_ID_t *my_id){
+void parse_apic_id(cpuid_info_t info_l0, cpuid_info_t info_l1, APIC_ID_t *my_id)
+{
 
     // Get the SMT ID
     uint64_t smt_mask_width = info_l0.eax & 0x1f;
@@ -116,7 +108,7 @@ parse_apic_id(cpuid_info_t info_l0, cpuid_info_t info_l1, APIC_ID_t *my_id){
 
     // Get the core ID
     uint64_t core_mask_width = info_l1.eax & 0x1f;
-    uint64_t core_mask = (~((-1) << core_mask_width ) ) ^ smt_mask;
+    uint64_t core_mask = (~((-1) << core_mask_width)) ^ smt_mask;
     my_id->core_id = (info_l1.edx & core_mask) >> smt_mask_width;
 
     // Get the package ID
@@ -124,59 +116,56 @@ parse_apic_id(cpuid_info_t info_l0, cpuid_info_t info_l1, APIC_ID_t *my_id){
     my_id->pkg_id = (info_l1.edx & pkg_mask) >> core_mask_width;
 }
 
-
-
 // For documentation, see:
 // http://software.intel.com/en-us/articles/intel-64-architecture-processor-topology-enumeration
-int
-build_topology() {
+int build_topology()
+{
 
     int err;
-    uint64_t i,j;
+    uint64_t i, j;
     uint64_t max_pkg = 0;
     os_cpu_count = sysconf(_SC_NPROCESSORS_CONF);
     cpu_set_t curr_context;
     cpu_set_t prev_context;
 
     // Construct an os map: os_map[APIC_ID ... APIC_ID]
-    os_map = (APIC_ID_t *) malloc(os_cpu_count * sizeof(APIC_ID_t));
+    os_map = (APIC_ID_t *)malloc(os_cpu_count * sizeof(APIC_ID_t));
 
-    for(i=0; i < os_cpu_count; i++){
+    for (i = 0; i < os_cpu_count; i++) {
 
-        err = bind_cpu(i, &prev_context);
+	err = bind_cpu(i, &prev_context);
 
-        cpuid_info_t info_l0 = get_processor_topology(0);
-        cpuid_info_t info_l1 = get_processor_topology(1);
+	cpuid_info_t info_l0 = get_processor_topology(0);
+	cpuid_info_t info_l1 = get_processor_topology(1);
 
-        os_map[i].os_id = i;
-        parse_apic_id(info_l0, info_l1, &os_map[i]);
+	os_map[i].os_id = i;
+	parse_apic_id(info_l0, info_l1, &os_map[i]);
 
-        num_core_threads = info_l0.ebx & 0xffff;
-        num_pkg_threads = info_l1.ebx & 0xffff;
+	num_core_threads = info_l0.ebx & 0xffff;
+	num_pkg_threads = info_l1.ebx & 0xffff;
 
-        if(os_map[i].pkg_id > max_pkg)
-            max_pkg = os_map[i].pkg_id;
+	if (os_map[i].pkg_id > max_pkg)
+	    max_pkg = os_map[i].pkg_id;
 
-        err = bind_context(&prev_context, NULL);
+	err = bind_context(&prev_context, NULL);
 
-        //printf("smt_id: %u core_id: %u pkg_id: %u os_id: %u\n",
-        //   os_map[i].smt_id, os_map[i].core_id, os_map[i].pkg_id, os_map[i].os_id);
-
+	// printf("smt_id: %u core_id: %u pkg_id: %u os_id: %u\n",
+	//   os_map[i].smt_id, os_map[i].core_id, os_map[i].pkg_id, os_map[i].os_id);
     }
 
     num_pkg_cores = num_pkg_threads / num_core_threads;
     num_nodes = max_pkg + 1;
 
     // Construct a pkg map: pkg_map[pkg id][APIC_ID ... APIC_ID]
-    pkg_map = (APIC_ID_t **) malloc(num_nodes * sizeof(APIC_ID_t*));
-    for(i = 0; i < num_nodes; i++)
-        pkg_map[i] = (APIC_ID_t *) malloc(num_pkg_threads * sizeof(APIC_ID_t));
+    pkg_map = (APIC_ID_t **)malloc(num_nodes * sizeof(APIC_ID_t *));
+    for (i = 0; i < num_nodes; i++)
+	pkg_map[i] = (APIC_ID_t *)malloc(num_pkg_threads * sizeof(APIC_ID_t));
 
     uint64_t p, t;
-    for(i = 0; i < os_cpu_count; i++){
-        p = os_map[i].pkg_id;
-        t = os_map[i].smt_id * num_pkg_cores + os_map[i].core_id;
-        pkg_map[p][t] = os_map[i];
+    for (i = 0; i < os_cpu_count; i++) {
+	p = os_map[i].pkg_id;
+	t = os_map[i].smt_id * num_pkg_cores + os_map[i].core_id;
+	pkg_map[p][t] = os_map[i];
     }
 
     return err;
@@ -188,74 +177,76 @@ build_topology() {
  * This function must be called before calling any other function from the power_gov library.
  * \return 0 on success, -1 otherwise
  */
-int
-init_rapl()
+int init_rapl()
 {
-    int      err = 0;
+    int err = 0;
 
     cpuid_info_t sig;
     sig = get_vendor_signature();
-	if (sig.ebx != 0x756e6547 || sig.ecx != 0x6c65746e || sig.edx != 0x49656e69) {
-        char vendor[12];
-        get_vendor_name(vendor);
-        fprintf(stderr, "The processor on the working machine is not from Intel. Found %s-processor instead.\n", vendor);
-        return MY_ERROR;
+    if (sig.ebx != 0x756e6547 || sig.ecx != 0x6c65746e || sig.edx != 0x49656e69) {
+	char vendor[12];
+	get_vendor_name(vendor);
+	fprintf(stderr, "The processor on the working machine is not from Intel. Found %s-processor instead.\n",
+		vendor);
+	return MY_ERROR;
     }
 
     unsigned int family;
     processor_signature = get_processor_signature();
     family = (processor_signature >> 8) & 0xf;
     if (family != 6) {
-        // CPUID.family == 6 means it's anything from Pentium Pro (1995) to the latest Kaby Lake (2017) except "Netburst" 
-        fprintf(stderr, "The Intel processor must be from family 6, but instead a cpu from family %d was found.\n", family);
-        return MY_ERROR;
+	// CPUID.family == 6 means it's anything from Pentium Pro (1995) to the latest Kaby Lake (2017) except
+	// "Netburst"
+	fprintf(stderr, "The Intel processor must be from family 6, but instead a cpu from family %d was found.\n",
+		family);
+	return MY_ERROR;
     }
 
     err = build_topology();
     if (err) {
-        fprintf(stderr, "An error occured while binding the cpu and/or the context.\n");
-        return MY_ERROR;
+	fprintf(stderr, "An error occured while binding the cpu and/or the context.\n");
+	return MY_ERROR;
     }
 
     err = open_msr_fd(num_nodes);
     if (err) {
-        fprintf(stderr, "An error occurred while opening the msr file through a FD.\n");
-        return MY_ERROR;
+	fprintf(stderr, "An error occurred while opening the msr file through a FD.\n");
+	return MY_ERROR;
     }
 
     drop_root_privileges_by_id(PERMANENT, UID_NOBODY, GID_NOGROUP);
 
     // calloc sets the allocated memory to zero (unlike malloc, where this is not the case)
-    msr_support_table = (unsigned char*) calloc(MSR_SUPPORT_MASK, sizeof(unsigned char));
+    msr_support_table = (unsigned char *)calloc(MSR_SUPPORT_MASK, sizeof(unsigned char));
 
     uint64_t msr;
     int cpu = 0;
     int err_read_msr = 0;
 
     err_read_msr = read_msr(cpu, MSR_RAPL_POWER_UNIT, &msr);
-    msr_support_table[MSR_RAPL_POWER_UNIT & MSR_SUPPORT_MASK]          = !err_read_msr;
+    msr_support_table[MSR_RAPL_POWER_UNIT & MSR_SUPPORT_MASK] = !err_read_msr;
 
     err_read_msr = read_msr(cpu, MSR_RAPL_PKG_POWER_LIMIT, &msr);
-    msr_support_table[MSR_RAPL_PKG_POWER_LIMIT & MSR_SUPPORT_MASK]     = !err_read_msr;
+    msr_support_table[MSR_RAPL_PKG_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
     err_read_msr = read_msr(cpu, MSR_RAPL_PKG_ENERGY_STATUS, &msr);
-    msr_support_table[MSR_RAPL_PKG_ENERGY_STATUS & MSR_SUPPORT_MASK]   = !err_read_msr;
+    msr_support_table[MSR_RAPL_PKG_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
     err_read_msr = read_msr(cpu, MSR_RAPL_PKG_POWER_INFO, &msr);
-    msr_support_table[MSR_RAPL_PKG_POWER_INFO & MSR_SUPPORT_MASK]      = !err_read_msr;
+    msr_support_table[MSR_RAPL_PKG_POWER_INFO & MSR_SUPPORT_MASK] = !err_read_msr;
 
     err_read_msr = read_msr(cpu, MSR_RAPL_DRAM_POWER_LIMIT, &msr);
-    msr_support_table[MSR_RAPL_DRAM_POWER_LIMIT & MSR_SUPPORT_MASK]    = !err_read_msr;
+    msr_support_table[MSR_RAPL_DRAM_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
     err_read_msr = read_msr(cpu, MSR_RAPL_DRAM_ENERGY_STATUS, &msr);
-    msr_support_table[MSR_RAPL_DRAM_ENERGY_STATUS & MSR_SUPPORT_MASK]  = !err_read_msr;
+    msr_support_table[MSR_RAPL_DRAM_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
 
     err_read_msr = read_msr(cpu, MSR_RAPL_PP0_POWER_LIMIT, &msr);
-    msr_support_table[MSR_RAPL_PP0_POWER_LIMIT & MSR_SUPPORT_MASK]     = !err_read_msr;
+    msr_support_table[MSR_RAPL_PP0_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
     err_read_msr = read_msr(cpu, MSR_RAPL_PP0_ENERGY_STATUS, &msr);
-    msr_support_table[MSR_RAPL_PP0_ENERGY_STATUS & MSR_SUPPORT_MASK]   = !err_read_msr;
+    msr_support_table[MSR_RAPL_PP0_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
 
     err_read_msr = read_msr(cpu, MSR_RAPL_PP1_POWER_LIMIT, &msr);
-    msr_support_table[MSR_RAPL_PP1_POWER_LIMIT & MSR_SUPPORT_MASK]     = !err_read_msr;
+    msr_support_table[MSR_RAPL_PP1_POWER_LIMIT & MSR_SUPPORT_MASK] = !err_read_msr;
     err_read_msr = read_msr(cpu, MSR_RAPL_PP1_ENERGY_STATUS, &msr);
-    msr_support_table[MSR_RAPL_PP1_ENERGY_STATUS & MSR_SUPPORT_MASK]   = !err_read_msr;
+    msr_support_table[MSR_RAPL_PP1_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
 
     err_read_msr = read_msr(cpu, MSR_RAPL_PLATFORM_ENERGY_STATUS, &msr);
     msr_support_table[MSR_RAPL_PLATFORM_ENERGY_STATUS & MSR_SUPPORT_MASK] = !err_read_msr;
@@ -275,24 +266,23 @@ init_rapl()
  * power_gov library.
  * \return 0 on success
  */
-int
-terminate_rapl()
+int terminate_rapl()
 {
     uint64_t i;
 
     close_msr_fd();
 
-    if(NULL != os_map)
-        free(os_map);
+    if (NULL != os_map)
+	free(os_map);
 
-    if(NULL != pkg_map){
-        for(i = 0; i < num_nodes; i++)
-            free(pkg_map[i]);
-        free(pkg_map);
+    if (NULL != pkg_map) {
+	for (i = 0; i < num_nodes; i++)
+	    free(pkg_map[i]);
+	free(pkg_map);
     }
 
-    if(NULL != msr_support_table)
-        free(msr_support_table);
+    if (NULL != msr_support_table)
+	free(msr_support_table);
 
     return 0;
 }
@@ -301,8 +291,7 @@ terminate_rapl()
  * \brief Check if MSR is supported on this machine.
  * \return 1 if supported, 0 otherwise
  */
-uint64_t
-is_supported_msr(uint64_t msr)
+uint64_t is_supported_msr(uint64_t msr)
 {
     return (uint64_t)msr_support_table[msr & MSR_SUPPORT_MASK];
 }
@@ -310,36 +299,34 @@ is_supported_msr(uint64_t msr)
 /*!
  * \brief Check if power domain (PKG, PP0, PP1, DRAM) is supported on this machine.
  *
- * Currently server parts support: PKG, PP0 and DRAM and
- * client parts support PKG, PP0 and PP1.
+ * Currently server parts support: PKG, PP0 and DRAM and client parts support PKG, PP0 and PP1.
  *
  * \return 1 if supported, 0 otherwise
  */
-uint64_t
-is_supported_domain(uint64_t power_domain)
+uint64_t is_supported_domain(uint64_t power_domain)
 {
     uint64_t supported = 0;
 
     switch (power_domain) {
     case RAPL_PKG:
-        supported = is_supported_msr(MSR_RAPL_PKG_POWER_LIMIT);
-        supported &= is_supported_msr(MSR_RAPL_PKG_ENERGY_STATUS);
-        break;
+	supported = is_supported_msr(MSR_RAPL_PKG_POWER_LIMIT);
+	supported &= is_supported_msr(MSR_RAPL_PKG_ENERGY_STATUS);
+	break;
     case RAPL_PP0:
-        supported = is_supported_msr(MSR_RAPL_PP0_POWER_LIMIT);
-        supported &= is_supported_msr(MSR_RAPL_PP0_ENERGY_STATUS);
-        break;
+	supported = is_supported_msr(MSR_RAPL_PP0_POWER_LIMIT);
+	supported &= is_supported_msr(MSR_RAPL_PP0_ENERGY_STATUS);
+	break;
     case RAPL_PP1:
-        supported = is_supported_msr(MSR_RAPL_PP1_POWER_LIMIT);
-        supported &= is_supported_msr(MSR_RAPL_PP1_ENERGY_STATUS);
-        break;
+	supported = is_supported_msr(MSR_RAPL_PP1_POWER_LIMIT);
+	supported &= is_supported_msr(MSR_RAPL_PP1_ENERGY_STATUS);
+	break;
     case RAPL_DRAM:
-        supported = is_supported_msr(MSR_RAPL_DRAM_POWER_LIMIT);
-        supported &= is_supported_msr(MSR_RAPL_DRAM_ENERGY_STATUS);
-        break;
+	supported = is_supported_msr(MSR_RAPL_DRAM_POWER_LIMIT);
+	supported &= is_supported_msr(MSR_RAPL_DRAM_ENERGY_STATUS);
+	break;
     case RAPL_PSYS:
-        supported = is_supported_msr(MSR_RAPL_PLATFORM_ENERGY_STATUS);
-        break;
+	supported = is_supported_msr(MSR_RAPL_PLATFORM_ENERGY_STATUS);
+	break;
     }
 
     return supported;
@@ -348,41 +335,37 @@ is_supported_domain(uint64_t power_domain)
 /*!
  * \brief Get the number of RAPL nodes on this machine.
  *
- * Get the number of package power domains, that you can control using RAPL.
- * This is equal to the number of CPU packages in the system.
+ * Get the number of package power domains, that you can control using RAPL. This is equal to the number of CPU packages
+ * in the system.
  *
  * \return number of RAPL nodes.
  */
-uint64_t
-get_num_rapl_nodes()
+uint64_t get_num_rapl_nodes()
 {
     return num_nodes;
 }
 
-uint64_t
-get_cpu_from_node(uint64_t node)
+uint64_t get_cpu_from_node(uint64_t node)
 {
     return pkg_map[node][0].os_id;
 }
 
-int
-get_rapl_unit_multiplier(uint64_t                cpu,
-                         rapl_unit_multiplier_t *unit_obj)
+int get_rapl_unit_multiplier(uint64_t cpu, rapl_unit_multiplier_t *unit_obj)
 {
-    int                        err = 0;
-    uint64_t                   msr;
+    int err = 0;
+    uint64_t msr;
     rapl_unit_multiplier_msr_t unit_msr;
 
     err = !is_supported_msr(MSR_RAPL_POWER_UNIT);
     if (!err) {
-        err = read_msr(cpu, MSR_RAPL_POWER_UNIT, &msr);
+	err = read_msr(cpu, MSR_RAPL_POWER_UNIT, &msr);
     }
     if (!err) {
-        unit_msr = *(rapl_unit_multiplier_msr_t *)&msr;
+	unit_msr = *(rapl_unit_multiplier_msr_t *)&msr;
 
-        unit_obj->time = 1.0 / (double)(B2POW(unit_msr.time));
-        unit_obj->energy = 1.0 / (double)(B2POW(unit_msr.energy));
-        unit_obj->power = 1.0 / (double)(B2POW(unit_msr.power));
+	unit_obj->time = 1.0 / (double)(B2POW(unit_msr.time));
+	unit_obj->energy = 1.0 / (double)(B2POW(unit_msr.energy));
+	unit_obj->power = 1.0 / (double)(B2POW(unit_msr.power));
     }
 
     return err;
@@ -390,34 +373,31 @@ get_rapl_unit_multiplier(uint64_t                cpu,
 
 /* Common methods (should not be interfaced directly) */
 
-int
-get_total_energy_consumed(uint64_t  cpu,
-                          uint64_t  msr_address,
-                          double   *total_energy_consumed_joules)
+int get_total_energy_consumed(uint64_t cpu, uint64_t msr_address, double *total_energy_consumed_joules)
 {
-    int                 err = 0;
-    uint64_t            msr;
+    int err = 0;
+    uint64_t msr;
     energy_status_msr_t domain_msr;
     cpu_set_t old_context;
 
     err = !is_supported_msr(msr_address);
     if (!err) {
-        bind_cpu(cpu, &old_context); // improve performance on Linux
-        err = read_msr(cpu, msr_address, &msr);
-        bind_context(&old_context, NULL);
+	bind_cpu(cpu, &old_context); // improve performance on Linux
+	err = read_msr(cpu, msr_address, &msr);
+	bind_context(&old_context, NULL);
     }
 
-    if(!err) {
-        domain_msr = *(energy_status_msr_t *)&msr;
+    if (!err) {
+	domain_msr = *(energy_status_msr_t *)&msr;
 
-        switch (msr_address) {
-        case  MSR_RAPL_DRAM_ENERGY_STATUS:
-            *total_energy_consumed_joules = RAPL_DRAM_ENERGY_UNIT * domain_msr.total_energy_consumed;
-            break;
-        default:
-            *total_energy_consumed_joules = RAPL_ENERGY_UNIT * domain_msr.total_energy_consumed;
-            break;
-        }
+	switch (msr_address) {
+	case MSR_RAPL_DRAM_ENERGY_STATUS:
+	    *total_energy_consumed_joules = RAPL_DRAM_ENERGY_UNIT * domain_msr.total_energy_consumed;
+	    break;
+	default:
+	    *total_energy_consumed_joules = RAPL_ENERGY_UNIT * domain_msr.total_energy_consumed;
+	    break;
+	}
     }
 
     return err;
@@ -426,14 +406,12 @@ get_total_energy_consumed(uint64_t  cpu,
 /*!
  * \brief Get a pointer to the RAPL PKG energy consumed register.
  *
- * This read-only register provides energy consumed in joules
- * for the package power domain since the last machine reboot (or energy register wraparound)
+ * This read-only register provides energy consumed in joules for the package power domain since the last machine reboot
+ * (or energy register wraparound)
  *
  * \return 0 on success, -1 otherwise
  */
-int
-get_pkg_total_energy_consumed(uint64_t  node,
-                              double   *total_energy_consumed_joules)
+int get_pkg_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
 {
     uint64_t cpu = get_cpu_from_node(node);
     return get_total_energy_consumed(cpu, MSR_RAPL_PKG_ENERGY_STATUS, total_energy_consumed_joules);
@@ -442,8 +420,7 @@ get_pkg_total_energy_consumed(uint64_t  node,
 /*
  * Energy units are either hard-coded, or come from RAPL Energy Unit MSR.
  */
-double
-rapl_dram_energy_units_probe(double rapl_energy_units)
+double rapl_dram_energy_units_probe(double rapl_energy_units)
 {
     switch (processor_signature & 0xfffffff0) {
     case CPU_INTEL_HASWELL_X:
@@ -452,23 +429,21 @@ rapl_dram_energy_units_probe(double rapl_energy_units)
     case CPU_INTEL_SKYLAKE_X:
     case CPU_INTEL_XEON_PHI_KNL:
     case CPU_INTEL_XEON_PHI_KNM:
-        return 15.3E-6;
+	return 15.3E-6;
     default:
-        return rapl_energy_units;
+	return rapl_energy_units;
     }
 }
 
 /*!
  * \brief Get a pointer to the RAPL DRAM energy consumed register.
  *
- * This read-only register provides energy consumed in joules
- * for the DRAM power domain since the last machine reboot (or energy register wraparound)
+ * This read-only register provides energy consumed in joules for the DRAM power domain since the last machine reboot
+ * (or energy register wraparound)
  *
  * \return 0 on success, -1 otherwise
  */
-int
-get_dram_total_energy_consumed(uint64_t  node,
-                               double   *total_energy_consumed_joules)
+int get_dram_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
 {
     uint64_t cpu = get_cpu_from_node(node);
     return get_total_energy_consumed(cpu, MSR_RAPL_DRAM_ENERGY_STATUS, total_energy_consumed_joules);
@@ -477,14 +452,12 @@ get_dram_total_energy_consumed(uint64_t  node,
 /*!
  * \brief Get a pointer to the RAPL PP0 energy consumed register.
  *
- * This read-only register provides energy consumed in joules
- * for the PP0 (core) power domain since the last machine reboot (or energy register wraparound)
+ * This read-only register provides energy consumed in joules for the PP0 (core) power domain since the last machine
+ * reboot (or energy register wraparound)
  *
  * \return 0 on success, -1 otherwise
  */
-int
-get_pp0_total_energy_consumed(uint64_t  node,
-                              double   *total_energy_consumed_joules)
+int get_pp0_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
 {
     uint64_t cpu = get_cpu_from_node(node);
     return get_total_energy_consumed(cpu, MSR_RAPL_PP0_ENERGY_STATUS, total_energy_consumed_joules);
@@ -493,14 +466,12 @@ get_pp0_total_energy_consumed(uint64_t  node,
 /*!
  * \brief Get a pointer to the RAPL PP1 energy consumed register.
  *
- * This read-only register provides energy consumed in joules
- * for the PP1 (uncore) power domain since the last machine reboot (or energy register wraparound)
+ * This read-only register provides energy consumed in joules for the PP1 (uncore) power domain since the last machine
+ * reboot (or energy register wraparound)
  *
  * \return 0 on success, -1 otherwise
  */
-int
-get_pp1_total_energy_consumed(uint64_t  node,
-                              double   *total_energy_consumed_joules)
+int get_pp1_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
 {
     uint64_t cpu = get_cpu_from_node(node);
     return get_total_energy_consumed(cpu, MSR_RAPL_PP1_ENERGY_STATUS, total_energy_consumed_joules);
@@ -509,33 +480,28 @@ get_pp1_total_energy_consumed(uint64_t  node,
 /*!
  * \brief Get a pointer to the RAPL plattform energy (psys) consumed register.
  *
- * This read-only register provides energy consumed in joules
- * for the PSYS domain since the last machine reboot (or energy register wraparound)
- * 
- * According to Intel Software Devlopers Manual Volume 4, Table 2-38, the consumed 
- * energy is the total energy consumed by all devices in the plattform that receive
- * power from integrated power delivery mechanism. Included plattform devices are
- * processor cores, SOC, memory, add-on or peripheral devies that get powered directly
- * from the platform power delivery means.
- * 
+ * This read-only register provides energy consumed in joules for the PSYS domain since the last machine reboot (or
+ * energy register wraparound)
+ *
+ * According to Intel Software Devlopers Manual Volume 4, Table 2-38, the consumed energy is the total energy consumed
+ * by all devices in the plattform that receive power from integrated power delivery mechanism. Included plattform
+ * devices are processor cores, SOC, memory, add-on or peripheral devies that get powered directly from the platform
+ * power delivery means.
+ *
  * \return 0 on success, -1 otherwise
  */
-int
-get_psys_total_energy_consumed(uint64_t  node,
-                              double   *total_energy_consumed_joules)
+int get_psys_total_energy_consumed(uint64_t node, double *total_energy_consumed_joules)
 {
     uint64_t cpu = get_cpu_from_node(node);
     return get_total_energy_consumed(cpu, MSR_RAPL_PLATFORM_ENERGY_STATUS, total_energy_consumed_joules);
 }
 
-double
-convert_to_watts(unsigned int raw)
+double convert_to_watts(unsigned int raw)
 {
     return RAPL_POWER_UNIT * raw;
 }
 
-double
-convert_to_seconds(unsigned int raw)
+double convert_to_seconds(unsigned int raw)
 {
     return RAPL_TIME_UNIT * raw;
 }
@@ -543,65 +509,60 @@ convert_to_seconds(unsigned int raw)
 /*!
  * \brief Get a pointer to the RAPL PKG power info register
  *
- * This read-only register provides information about
- * the max/min power limiting settings available on the machine.
- * This register is defined in the pkg_rapl_parameters_t data structure.
+ * This read-only register provides information about the max/min power limiting settings available on the machine. This
+ * register is defined in the pkg_rapl_parameters_t data structure.
  *
  * \return 0 on success, -1 otherwise
  */
-int
-get_pkg_rapl_parameters(unsigned int           node,
-                        pkg_rapl_parameters_t *pkg_obj)
+int get_pkg_rapl_parameters(unsigned int node, pkg_rapl_parameters_t *pkg_obj)
 {
-    int                   err = 0;
-    uint64_t              msr;
+    int err = 0;
+    uint64_t msr;
     rapl_parameters_msr_t domain_msr;
 
     err = !is_supported_msr(MSR_RAPL_PKG_POWER_INFO);
     if (!err) {
-        unsigned int cpu = get_cpu_from_node(node);
-        err = read_msr(cpu, MSR_RAPL_PKG_POWER_INFO, &msr);
+	unsigned int cpu = get_cpu_from_node(node);
+	err = read_msr(cpu, MSR_RAPL_PKG_POWER_INFO, &msr);
     }
 
     if (!err) {
-        domain_msr = *(rapl_parameters_msr_t *)&msr;
+	domain_msr = *(rapl_parameters_msr_t *)&msr;
 
-        pkg_obj->thermal_spec_power_watts = convert_to_watts(domain_msr.thermal_spec_power);
-        pkg_obj->minimum_power_watts = convert_to_watts(domain_msr.minimum_power);
-        pkg_obj->maximum_power_watts = convert_to_watts(domain_msr.maximum_power);
-        pkg_obj->maximum_limit_time_window_seconds = convert_to_seconds(domain_msr.maximum_limit_time_window);
+	pkg_obj->thermal_spec_power_watts = convert_to_watts(domain_msr.thermal_spec_power);
+	pkg_obj->minimum_power_watts = convert_to_watts(domain_msr.minimum_power);
+	pkg_obj->maximum_power_watts = convert_to_watts(domain_msr.maximum_power);
+	pkg_obj->maximum_limit_time_window_seconds = convert_to_seconds(domain_msr.maximum_limit_time_window);
     }
 
     return err;
 }
 
-void
-calculate_probe_interval_time(struct timespec *signal_timelimit, double thermal_spec_power)
+void calculate_probe_interval_time(struct timespec *signal_timelimit, double thermal_spec_power)
 {
-    double result = ((pow(2,32) - 1) * RAPL_ENERGY_UNIT) / thermal_spec_power;
+    double result = ((pow(2, 32) - 1) * RAPL_ENERGY_UNIT) / thermal_spec_power;
     result = result / 2 - 1;
 
     long seconds = floor(result);
-    long nano_seconds = result * pow(10,9) - seconds * pow(10,9);
-    
+    long nano_seconds = result * pow(10, 9) - seconds * pow(10, 9);
+
     signal_timelimit->tv_sec = seconds;
     signal_timelimit->tv_nsec = nano_seconds;
 }
 
 /* Utilities */
 
-int
-read_rapl_units()
+int read_rapl_units()
 {
-    int                    err = 0;
+    int err = 0;
     rapl_unit_multiplier_t unit_multiplier;
 
     err = get_rapl_unit_multiplier(0, &unit_multiplier);
     if (!err) {
-        RAPL_TIME_UNIT = unit_multiplier.time;
-        RAPL_ENERGY_UNIT = unit_multiplier.energy;
-        RAPL_DRAM_ENERGY_UNIT = rapl_dram_energy_units_probe(unit_multiplier.energy);
-        RAPL_POWER_UNIT = unit_multiplier.power;
+	RAPL_TIME_UNIT = unit_multiplier.time;
+	RAPL_ENERGY_UNIT = unit_multiplier.energy;
+	RAPL_DRAM_ENERGY_UNIT = rapl_dram_energy_units_probe(unit_multiplier.energy);
+	RAPL_POWER_UNIT = unit_multiplier.power;
     }
 
     return err;

--- a/rapl.h
+++ b/rapl.h
@@ -36,10 +36,10 @@ enum RAPL_DOMAIN { PKG, PP0, PP1, DRAM, PSYS };
 char *RAPL_DOMAIN_STRINGS[RAPL_NR_DOMAIN];
 
 typedef struct APIC_ID_t {
-    uint64_t smt_id;
-    uint64_t core_id;
-    uint64_t pkg_id;
-    uint64_t os_id;
+  uint64_t smt_id;
+  uint64_t core_id;
+  uint64_t pkg_id;
+  uint64_t os_id;
 } APIC_ID_t;
 
 int init_rapl();
@@ -61,10 +61,10 @@ int get_psys_total_energy_consumed(uint64_t node, double *total_energy_consumed)
 
 /*! \brief RAPL parameters info structure, PKG domain */
 typedef struct pkg_rapl_parameters_t {
-    double thermal_spec_power_watts;
-    double minimum_power_watts;
-    double maximum_power_watts;
-    double maximum_limit_time_window_seconds;
+  double thermal_spec_power_watts;
+  double minimum_power_watts;
+  double maximum_power_watts;
+  double maximum_limit_time_window_seconds;
 } pkg_rapl_parameters_t;
 int get_pkg_rapl_parameters(unsigned int node, pkg_rapl_parameters_t *rapl_parameters);
 

--- a/rapl.h
+++ b/rapl.h
@@ -12,7 +12,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 /* Written by Martin Dimitrov, Carl Strickland */
 
-
 /*! \file rapl.h
  *  Library header file.
  */
@@ -25,16 +24,16 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #define MY_ERROR -1
 
 /* Power Domains */
-#define RAPL_PKG  0 /*!< \brief Package power domain */
-#define RAPL_PP0  1 /*!< \brief Core power domain */
-#define RAPL_PP1  2 /*!< \brief Uncore power domain */
-#define RAPL_DRAM 3 /*!< \brief DRAM power domain */
-#define RAPL_PSYS 4 /*!< \brief PLATFORM power domain */
+#define RAPL_PKG 0       /*!< \brief Package power domain */
+#define RAPL_PP0 1       /*!< \brief Core power domain */
+#define RAPL_PP1 2       /*!< \brief Uncore power domain */
+#define RAPL_DRAM 3      /*!< \brief DRAM power domain */
+#define RAPL_PSYS 4      /*!< \brief PLATFORM power domain */
 #define RAPL_NR_DOMAIN 5 /*!< \brief Number of power domains */
 
 enum RAPL_DOMAIN { PKG, PP0, PP1, DRAM, PSYS };
 
-char* RAPL_DOMAIN_STRINGS[RAPL_NR_DOMAIN];
+char *RAPL_DOMAIN_STRINGS[RAPL_NR_DOMAIN];
 
 typedef struct APIC_ID_t {
     uint64_t smt_id;
@@ -46,10 +45,8 @@ typedef struct APIC_ID_t {
 int init_rapl();
 int terminate_rapl();
 
-/* Wraparound value for the total energy consumed. It is computed within
- * init_rapl().
- */
-double MAX_ENERGY_STATUS_JOULES;   /* default: 65536 */
+// Wraparound value for the total energy consumed. It is computed within init_rapl().
+double MAX_ENERGY_STATUS_JOULES; /* default: 65536 */
 
 uint64_t get_num_rapl_nodes();
 

--- a/util.c
+++ b/util.c
@@ -26,7 +26,8 @@ static gid_t orig_groups[NGROUPS_MAX];
 
 /**
  * Drop privileges permanently in case a nonzero value is passed; otherwise, the privilege drop is
- * temporary.
+ * temporary. If either a positive uid or gid is passed as parameter, the value is taken as the new
+ * uid or gid, respectively.
  *
  * Warning:
  * If any problems are encountered in attempting to perform the task, abort() is called, terminating
@@ -34,18 +35,9 @@ static gid_t orig_groups[NGROUPS_MAX];
  * safest to assume that the process is in an unknown state, and you should not allow it to
  * continue.
  */
-void drop_root_privileges(int permanent) {
-  gid_t newgid = getgid(), oldgid = getegid();
-  uid_t newuid = getuid(), olduid = geteuid();
-
-  // newgid = 1000;
-  // newuid = 1000;
-
-  printf("-----BEFORE-------\n");
-  printf("newgid: %d\n", newgid);
-  printf("oldgid: %d\n", oldgid);
-  printf("newuid: %d\n", newuid);
-  printf("olduid: %d\n", olduid);
+void drop_root_privileges_by_id(int permanent, uid_t uid, gid_t gid) {
+  gid_t newgid = gid > 0 ? gid : getgid(), oldgid = getegid();
+  uid_t newuid = uid > 0 ? uid : getuid(), olduid = geteuid();
 
   if (!permanent) {
     /* Save information about the privileges that are being dropped so that they can be restored
@@ -60,50 +52,62 @@ void drop_root_privileges(int permanent) {
    * before doing anything else because the setgroups() system call requires root privileges.  Drop
    * ancillary groups regardless of whether privileges are being dropped temporarily or permanently.
    */
-  if (!olduid)
+  if (!olduid) {
     setgroups(1, &newgid);
+  }
 
   if (newgid != oldgid) {
 #if !defined(linux)
     setegid(newgid);
-    if (permanent && setgid(newgid) == -1)
+    if (permanent && setgid(newgid) == -1) {
       abort();
+    }
 #else
-    if (setregid((permanent ? newgid : -1), newgid) == -1)
+    if (setregid((permanent ? newgid : -1), newgid) == -1) {
       abort();
+    }
 #endif
   }
 
   if (newuid != olduid) {
 #if !defined(linux)
     seteuid(newuid);
-    if (permanent && setuid(newuid) == -1)
+    if (permanent && setuid(newuid) == -1) {
       abort();
+    }
 #else
-    if (setreuid((permanent ? newuid : -1), newuid) == -1)
+    if (setreuid((permanent ? newuid : -1), newuid) == -1) {
       abort();
+    }
 #endif
   }
 
   /* verify that the changes were successful */
   if (permanent) {
-    if (newgid != oldgid && (setegid(oldgid) != -1 || getegid() != newgid))
+    if (newgid != oldgid && (setegid(oldgid) != -1 || getegid() != newgid)) {
       abort();
-    if (newuid != olduid && (seteuid(olduid) != -1 || geteuid() != newuid))
+    }
+    if (newuid != olduid && (seteuid(olduid) != -1 || geteuid() != newuid)) {
       abort();
+    }
   } else {
-    if (newgid != oldgid && getegid() != newgid)
+    if (newgid != oldgid && getegid() != newgid) {
       abort();
-    if (newuid != olduid && geteuid() != newuid)
+    }
+    if (newuid != olduid && geteuid() != newuid) {
       abort();
+    }
   }
+}
 
-  printf("-----AFTER-------\n");
-  printf("newgid: %d\n", newgid);
-  printf("oldgid: %d\n", oldgid);
-  printf("newuid: %d\n", newuid);
-  printf("olduid: %d\n", olduid);
-  printf("-----------------\n\n");
+/**
+ * Drop privileges permanently in case a nonzero value is passed; otherwise, the
+ * privilege drop is temporary.
+ *
+ * See #drop_root_privileges_by_id(int, uid_t, gid_t) for further information.
+ */
+void drop_root_privileges(int permanent) {
+  drop_root_privileges_by_id(permanent, -1, -1);
 }
 
 /**
@@ -116,14 +120,19 @@ void drop_root_privileges(int permanent) {
  * continue.
  */
 void restore_root_privileges(void) {
-  if (geteuid() != orig_uid)
-    if (seteuid(orig_uid) == -1 || geteuid() != orig_uid)
+  if (geteuid() != orig_uid) {
+    if (seteuid(orig_uid) == -1 || geteuid() != orig_uid) {
       abort();
+    }
+  }
 
-  if (getegid() != orig_gid)
-    if (setegid(orig_gid) == -1 || getegid() != orig_gid)
+  if (getegid() != orig_gid) {
+    if (setegid(orig_gid) == -1 || getegid() != orig_gid) {
       abort();
+    }
+  }
 
-  if (!orig_uid)
+  if (!orig_uid) {
     setgroups(orig_ngroups, orig_groups);
+  }
 }

--- a/util.c
+++ b/util.c
@@ -10,118 +10,111 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <sys/param.h>
-#include <sys/types.h>
-#include <stdlib.h>
-#include <unistd.h>
 #include <grp.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <sys/param.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "util.h"
 
-
-static int   orig_ngroups = -1;
+static int orig_ngroups = -1;
 static gid_t orig_gid = -1;
 static uid_t orig_uid = -1;
 static gid_t orig_groups[NGROUPS_MAX];
 
-
 /**
- * Drop privileges permanently in case a nonzero value is passed; otherwise, the 
- * privilege drop is temporary. If either a positive uid or gid is passed as parameter,
- * the value is taken as the new uid or gid, respectively.
+ * Drop privileges permanently in case a nonzero value is passed; otherwise, the privilege drop is temporary. If either
+ * a positive uid or gid is passed as parameter, the value is taken as the new uid or gid, respectively.
  *
- * Warning: 
- * If any problems are encountered in attempting to perform the task, abort()
- * is called, terminating the process immediately. If any manipulation of privileges
- * cannot complete successfully, it's safest to assume that the process is in an
- * unknown state, and you should not allow it to continue.
+ * Warning:
+ * If any problems are encountered in attempting to perform the task, abort() is called, terminating the process
+ * immediately. If any manipulation of privileges cannot complete successfully, it's safest to assume that the process
+ * is in an unknown state, and you should not allow it to continue.
  */
-void drop_root_privileges_by_id(int permanent, uid_t uid, gid_t gid) {
+void drop_root_privileges_by_id(int permanent, uid_t uid, gid_t gid)
+{
     gid_t newgid = gid > 0 ? gid : getgid(), oldgid = getegid();
     uid_t newuid = uid > 0 ? uid : getuid(), olduid = geteuid();
-   
+
     if (!permanent) {
-        /* Save information about the privileges that are being dropped so that they
-         * can be restored later.
-         */
-        orig_gid = oldgid;
-        orig_uid = olduid;
-        orig_ngroups = getgroups(NGROUPS_MAX, orig_groups);
+	// Save information about the privileges that are being dropped so that they can be restored later.
+	orig_gid = oldgid;
+	orig_uid = olduid;
+	orig_ngroups = getgroups(NGROUPS_MAX, orig_groups);
     }
-   
-    /* If root privileges are to be dropped, be sure to pare down the ancillary
-     * groups for the process before doing anything else because the setgroups()
-     * system call requires root privileges.  Drop ancillary groups regardless of
-     * whether privileges are being dropped temporarily or permanently.
-     */
-    if (!olduid) 
-        setgroups(1, &newgid);
-   
+
+    // If root privileges are to be dropped, be sure to pare down the ancillary groups for the process before doing
+    // anything else because the setgroups() system call requires root privileges. Drop ancillary groups regardless of
+    // whether privileges are being dropped temporarily or permanently.
+    if (!olduid)
+	setgroups(1, &newgid);
+
     if (newgid != oldgid) {
 #if !defined(linux)
-        setegid(newgid);
-        if (permanent && setgid(newgid) == -1)
-            abort();
+	setegid(newgid);
+	if (permanent && setgid(newgid) == -1)
+	    abort();
 #else
-        if (setregid((permanent ? newgid : -1), newgid) == -1)
-            abort();
+	if (setregid((permanent ? newgid : -1), newgid) == -1)
+	    abort();
 #endif
     }
-   
+
     if (newuid != olduid) {
 #if !defined(linux)
-        seteuid(newuid);
-        if (permanent && setuid(newuid) == -1) 
-            abort();
+	seteuid(newuid);
+	if (permanent && setuid(newuid) == -1)
+	    abort();
 #else
-        if (setreuid((permanent ? newuid : -1), newuid) == -1)
-            abort();
+	if (setreuid((permanent ? newuid : -1), newuid) == -1)
+	    abort();
 #endif
     }
-   
-    /* verify that the changes were successful */
+
+    // verify that the changes were successful
     if (permanent) {
-        if (newgid != oldgid && (setegid(oldgid) != -1 || getegid() != newgid))
-            abort();
-        if (newuid != olduid && (seteuid(olduid) != -1 || geteuid() != newuid))
-            abort();
+	if (newgid != oldgid && (setegid(oldgid) != -1 || getegid() != newgid))
+	    abort();
+	if (newuid != olduid && (seteuid(olduid) != -1 || geteuid() != newuid))
+	    abort();
     } else {
-        if (newgid != oldgid && getegid() != newgid)
-            abort();
-        if (newuid != olduid && geteuid() != newuid)
-            abort();
+	if (newgid != oldgid && getegid() != newgid)
+	    abort();
+	if (newuid != olduid && geteuid() != newuid)
+	    abort();
     }
 }
 
 /**
- * Drop privileges permanently in case a nonzero value is passed; otherwise, the
- * privilege drop is temporary.
+ * Drop privileges permanently in case a nonzero value is passed; otherwise, the privilege drop is temporary.
  *
  * See #drop_root_privileges_by_id(int, uid_t, gid_t) for further information.
  */
-void drop_root_privileges(int permanent) {
+void drop_root_privileges(int permanent)
+{
     drop_root_privileges_by_id(permanent, -1, -1);
 }
 
 /**
  * Restore privileges to what they were at the last call to drop_root_privileges().
- * 
- * Warning: 
- * If any problems are encountered in attempting to perform the task, abort()
- * is called, terminating the process immediately. If any manipulation of privileges
- * cannot complete successfully, it's safest to assume that the process is in an
- * unknown state, and you should not allow it to continue.
+ *
+ * Warning:
+ * If any problems are encountered in attempting to perform the task, abort() is called, terminating the process
+ * immediately. If any manipulation of privileges cannot complete successfully, it's safest to assume that the process
+ * is in an unknown state, and you should not allow it to continue.
  */
-void restore_root_privileges(void) {
+void restore_root_privileges(void)
+{
     if (geteuid() != orig_uid)
-        if (seteuid(orig_uid) == -1 || geteuid() != orig_uid)
-            abort();
-    
+	if (seteuid(orig_uid) == -1 || geteuid() != orig_uid)
+	    abort();
+
     if (getegid() != orig_gid)
-        if (setegid(orig_gid) == -1 || getegid() != orig_gid)
-            abort();
-    
+	if (setegid(orig_gid) == -1 || getegid() != orig_gid)
+	    abort();
+
     if (!orig_uid)
-        setgroups(orig_ngroups, orig_groups);
+	setgroups(orig_ngroups, orig_groups);
 }

--- a/util.h
+++ b/util.h
@@ -19,24 +19,21 @@ static const gid_t GID_NOGROUP = 65534;
 enum { TEMPORARY = 0, PERMANENT = 1 };
 
 /*
- * Documentation and source code can be found at (link from Nov. 28, 2017):
- * https://www.safaribooksonline.com/library/view/secure-programming-cookbook/0596003943/ch01s03.html
+ * Documentation and source code can be found at
+ * https://www.safaribooksonline.com/library/view/secure-programming-cookbook/0596003943/ch01s03.html [link opened at
+ * Nov. 28, 2017]
  */
 
 /**
- * Drop any extra group or user privileges either permanently or temporarily,
- * depending on the value of the argument. If a nonzero value is passed,
- * privileges will be dropped permanently; otherwise, the privilege drop is
- * temporary. Custom values can be specified for uid and gid to be taken as
- * new id in the process.
+ * Drop any extra group or user privileges either permanently or temporarily, depending on the value of the argument. If
+ * a nonzero value is passed, privileges will be dropped permanently; otherwise, the privilege drop is temporary. Custom
+ * values can be specified for uid and gid to be taken as new id in the process.
  */
 void drop_root_privileges_by_id(int permanent, uid_t uid, gid_t gid);
 
 /**
- * Drop any extra group or user privileges either permanently or temporarily, 
- * depending on the value of the argument. If a nonzero value is passed, 
- * privileges will be dropped permanently; otherwise, the privilege drop is 
- * temporary.
+ * Drop any extra group or user privileges either permanently or temporarily, depending on the value of the argument. If
+ * a nonzero value is passed, privileges will be dropped permanently; otherwise, the privilege drop is temporary.
  */
 void drop_root_privileges(int permanent);
 

--- a/util.h
+++ b/util.h
@@ -20,20 +20,22 @@ enum { TEMPORARY = 0, PERMANENT = 1 };
 
 /*
  * Documentation and source code can be found at
- * https://www.safaribooksonline.com/library/view/secure-programming-cookbook/0596003943/ch01s03.html [link opened at
- * Nov. 28, 2017]
+ * https://www.safaribooksonline.com/library/view/secure-programming-cookbook/0596003943/ch01s03.html
+ * [link opened at Nov. 28, 2017]
  */
 
 /**
- * Drop any extra group or user privileges either permanently or temporarily, depending on the value of the argument. If
- * a nonzero value is passed, privileges will be dropped permanently; otherwise, the privilege drop is temporary. Custom
- * values can be specified for uid and gid to be taken as new id in the process.
+ * Drop any extra group or user privileges either permanently or temporarily, depending on the value
+ * of the argument. If a nonzero value is passed, privileges will be dropped permanently; otherwise,
+ * the privilege drop is temporary. Custom values can be specified for uid and gid to be taken as
+ * new id in the process.
  */
 void drop_root_privileges_by_id(int permanent, uid_t uid, gid_t gid);
 
 /**
- * Drop any extra group or user privileges either permanently or temporarily, depending on the value of the argument. If
- * a nonzero value is passed, privileges will be dropped permanently; otherwise, the privilege drop is temporary.
+ * Drop any extra group or user privileges either permanently or temporarily, depending on the value
+ * of the argument. If a nonzero value is passed, privileges will be dropped permanently; otherwise,
+ * the privilege drop is temporary.
  */
 void drop_root_privileges(int permanent);
 


### PR DESCRIPTION
The style format is based on the linux kernel code style, which is well documented at https://www.kernel.org/doc/html/v4.10/ . The only exception is that the indentation is kept at 4 spaces (just as before), and a column limit is set, which is currently a maximum of 120 characters per line. 
The changes are most visible in the classes cpu-energy-meter.c and rapl.c

The program used for formatting the code was 'clang' with the following specifications:
BasedOnStyle: LLVM
IndentWidth: 4
UseTab: Always
BreakBeforeBraces: Linux
AllowShortIfStatementsOnASingleLine: false
AllowShortLoopsOnASingleLine: false
AllowShortFunctionsOnASingleLine: false
IndentCaseLabels: false
ColumnLimit: 120